### PR TITLE
I think UID is better than "root" string.

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -296,9 +296,7 @@ fi
 ################
 
 # Got root?
-myWHOAMI=$(whoami)
-if [ "$myWHOAMI" != "root" ]
-  then
+if (( $EUID != 0 )); then
     echo "Need to run as root ..."
     exit
 fi


### PR DESCRIPTION
## I tested it on my Linux. The result was good.

<pre>
d@d:/root/dd$ cat d.sh 
#!/bin/bash

if (( $EUID != 0 )); then

    echo "not root"
    exit

fi
d@d:/root/dd$ ./d.sh 
not root
d@d:/root/dd$ su root
passwd: 
root@d:~/dd# ./d.sh 
root@d:~/dd# 
</pre>