### PR TITLE
Change method to get default Suricata interface

### DIFF
--- a/docker/suricata/Dockerfile
+++ b/docker/suricata/Dockerfile
@@ -34,4 +34,4 @@ RUN apk -U --no-cache add \
 #
 # Start suricata
 STOPSIGNAL SIGINT
-CMD SURICATA_CAPTURE_FILTER=$(update.sh $OINKCODE) && exec suricata -v -F $SURICATA_CAPTURE_FILTER -i $(/sbin/ip address | grep '^2: ' | awk '{ print $2 }' | tr -d [:punct:])
+CMD SURICATA_CAPTURE_FILTER=$(update.sh $OINKCODE) && exec suricata -v -F $SURICATA_CAPTURE_FILTER -i $(/sbin/ip address show | /usr/bin/awk '/inet.*brd/{ print $NF; exit }')

--- a/docker/suricata/Dockerfile.from.source
+++ b/docker/suricata/Dockerfile.from.source
@@ -135,4 +135,4 @@ RUN    apk -U add \
 #
 # Start suricata
 STOPSIGNAL SIGINT
-CMD SURICATA_CAPTURE_FILTER=$(update.sh $OINKCODE) && exec suricata -v -F $SURICATA_CAPTURE_FILTER -i $(/sbin/ip address | grep '^2: ' | awk '{ print $2 }' | tr -d [:punct:])
+CMD SURICATA_CAPTURE_FILTER=$(update.sh $OINKCODE) && exec suricata -v -F $SURICATA_CAPTURE_FILTER -i $(/sbin/ip address show | /usr/bin/awk '/inet.*brd/{ print $NF; exit }')


### PR DESCRIPTION
On some systems, interface number 2 is not always the correct one.
With AWK we now collect the first active interface having both an address and a broadcast.