### PR TITLE
Ansible: Set pip executable to pip3

### DIFF
--- a/cloud/ansible/openstack/roles/check/tasks/main.yaml
+++ b/cloud/ansible/openstack/roles/check/tasks/main.yaml
@@ -11,6 +11,7 @@
 - name: Install openstacksdk
   pip:
     name: openstacksdk
+    executable: pip3
 
 - name: Check if agent forwarding is enabled
   fail:


### PR DESCRIPTION
I experienced on Debian 10 that Ansible still auto discovers Python2/pip(2) which then fails the Playbook since we only install pip3.
Set the pip module executable explicitly to pip3 to avoid this.