### PR TITLE
 Explicitly add region name to clouds.yaml

### DIFF
--- a/cloud/ansible/openstack/clouds.yaml
+++ b/cloud/ansible/openstack/clouds.yaml
@@ -1,6 +1,7 @@
 clouds:
   open-telekom-cloud:
     profile: otc
+    region_name: eu-de
     auth:
       project_name: eu-de_your_project
       username: your_api_user

--- a/cloud/terraform/otc/clouds.yaml
+++ b/cloud/terraform/otc/clouds.yaml
@@ -1,5 +1,6 @@
 clouds:
   open-telekom-cloud:
+    region_name: eu-de
     auth:
       project_name: eu-de_your_project
       username: your_api_user


### PR DESCRIPTION
openstacksdk version 0.53.0 is released where this commit (https://github.com/openstack/openstacksdk/commit/6c7bdc617b8ea0d4e99d9bacb378b5316f454bb8) got merged.
It prepares for the upcoming OTC region in Amsterdam.
Now it is needed to explicitly set the region name parameter in the clouds.yaml config.

In Terraform the otc profile is not used, but let's keep those two files in sync (and if you want to deploy sth in eu-nl you have to specify the parameter anyways).