### PR TITLE
OTC: Retrieve Debian Image ID from Terraform Data Source

### DIFF
--- a/cloud/terraform/README.md
+++ b/cloud/terraform/README.md
@@ -93,7 +93,6 @@ In `otc/variables.tf`, you can change the additional variables:
 * `availability_zone`
 * `flavor`
 * `key_pair` - Specify an existing SSH key pair
-* `image_id`
 * `volume_size`  
 Furthermore you can configure the naming of the created infrastructure (per default everything gets prefixed with "tpot-", e.g. "tpot-router").
 

--- a/cloud/terraform/otc/main.tf
+++ b/cloud/terraform/otc/main.tf
@@ -1,3 +1,7 @@
+data "opentelekomcloud_images_image_v2" "debian" {
+  name = "Standard_Debian_10_latest"
+}
+
 resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
   name        = var.secgroup_name
   description = var.secgroup_desc
@@ -48,7 +52,7 @@ resource "opentelekomcloud_compute_instance_v2" "ecs_1" {
   }
 
   block_device {
-    uuid                  = var.image_id
+    uuid                  = data.opentelekomcloud_images_image_v2.debian.id
     source_type           = "image"
     volume_size           = var.volume_size
     destination_type      = "volume"

--- a/cloud/terraform/otc/variables.tf
+++ b/cloud/terraform/otc/variables.tf
@@ -49,11 +49,6 @@ variable "key_pair" {
   description = "Specify your SSH key pair"
 }
 
-variable "image_id" {
-  default = "cf471250-a755-4df8-8c42-6faa5a224ea0"
-  description = "Select a Debian 10 base image id"
-}
-
 variable "volume_size" {
   default = "128"
   description = "Set the volume size"


### PR DESCRIPTION
No need for updating the image ID in the future.
This will automatically retrieve the latest Debian 10 image from OTC.