### PR TITLE
Terraform: Use b64_url for ecs name

### DIFF
--- a/cloud/terraform/otc/main.tf
+++ b/cloud/terraform/otc/main.tf
@@ -34,7 +34,7 @@ resource "random_id" "tpot" {
 }
 
 resource "opentelekomcloud_ecs_instance_v1" "ecs_1" {
-  name     = random_id.tpot.b64_std
+  name     = random_id.tpot.b64_url
   image_id = data.opentelekomcloud_images_image_v2.debian.id
   flavor   = var.ecs_flavor
   vpc_id   = opentelekomcloud_vpc_v1.vpc_1.id


### PR DESCRIPTION
Previously it could happen that special characters were generated in the name.
Now it allows only letters, digits, underscore & hyphen to conform with ecs naming requirements.