### PR TITLE
Terraform improvements

### DIFF
--- a/cloud/terraform/cloud-init.yaml
+++ b/cloud/terraform/cloud-init.yaml
@@ -5,6 +5,7 @@ packages:
   - git
 
 runcmd:
+  - curl -sS --retry 5 https://github.com
   - git clone https://github.com/telekom-security/tpotce /root/tpot
   - /root/tpot/iso/installer/install.sh --type=auto --conf=/root/tpot.conf
   - rm /root/tpot.conf

--- a/cloud/terraform/otc/main.tf
+++ b/cloud/terraform/otc/main.tf
@@ -56,7 +56,7 @@ resource "opentelekomcloud_vpc_eip_v1" "eip_1" {
     type = "5_bgp"
   }
   bandwidth {
-    name       = "bandwidth-${random_id.tpot.b64_std}"
+    name       = "bandwidth-${random_id.tpot.b64_url}"
     size       = var.eip_size
     share_type = "PER"
   }


### PR DESCRIPTION
- Use b64_url for eip bandwidth name (fixes invalid random names)
- Test connection to github before git clone