### PR TITLE
Fix small typo in heimdall start.sh

### DIFF
--- a/docker/heimdall/dist/start.sh
+++ b/docker/heimdall/dist/start.sh
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 if [ "$(ls /var/lib/nginx/html/database)" = "" ] && [ "$HEIMDALL_PERSIST" = "YES" ];
   then
     tar xvfz /var/lib/nginx/first.tgz -C /


### PR DESCRIPTION
While looking through the files I found this small typo in the ` docker/heimdall/dist/start.sh`.