### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/elk/logstash/Dockerfile
+++ b/docker/elk/logstash/Dockerfile
@@ -15,7 +15,7 @@ RUN apk -U --no-cache add \
              libc6-compat \
              libzmq \
              nss && \
-    apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/community openjdk16-jre && \
+    apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing openjdk16-jre && \
 #
 # Get and install packages
     mkdir -p /etc/listbot && \


### PR DESCRIPTION
openjdk16-jre isn't provided by the ```community``` repo of alpine