### PR TITLE
Make a template for deploying T-Pot in multiple regions on AWS using terraform

### DIFF
--- a/cloud/terraform/aws/variables.tf
+++ b/cloud/terraform/aws/variables.tf
@@ -28,31 +28,31 @@ variable "ec2_instance_type" {
   default = "t3.large"
 }
 
-# Refer to https://wiki.debian.org/Cloud/AmazonEC2Image/Buster
+# Refer to https://wiki.debian.org/Cloud/AmazonEC2Image/Bullseye
 variable "ec2_ami" {
   type = map(string)
   default = {
-    "af-south-1"     = "ami-0272d4f5fb1b98a0d"
-    "ap-east-1"      = "ami-00d242e2f23abf6d2"
-    "ap-northeast-1" = "ami-001c6b4d627e8be53"
-    "ap-northeast-2" = "ami-0d841ed4bf80e764c"
-    "ap-northeast-3" = "ami-01b0a01d770321320"
-    "ap-south-1"     = "ami-04ba7e5bd7c6f6929"
-    "ap-southeast-1" = "ami-0dca3eabb09c32ae2"
-    "ap-southeast-2" = "ami-03ff8684dc585ddae"
-    "ca-central-1"   = "ami-08af22d7c0382fd83"
-    "eu-central-1"   = "ami-0f41e297b3c53fab8"
-    "eu-north-1"     = "ami-0bbc6a00971c77d6d"
-    "eu-south-1"     = "ami-03ff8684dc585ddae"
-    "eu-west-1"      = "ami-080684ad73d431a05"
-    "eu-west-2"      = "ami-04b259723891dfc53"
-    "eu-west-3"      = "ami-00662eead74f66895"
-    "me-south-1"     = "ami-021a6c6047091ab5b"
-    "sa-east-1"      = "ami-0aac091cce68a049c"
-    "us-east-1"      = "ami-05ad4ed7f9c48178b"
-    "us-east-2"      = "ami-07640f3f27c0ad3d3"
-    "us-west-1"      = "ami-0c053f1d5f22eb09f"
-    "us-west-2"      = "ami-090cd3aed687b1ee1"
+    "af-south-1"     = "ami-0c372f041acae6d49"
+    "ap-east-1"      = "ami-079b8d011d4655385"
+    "ap-northeast-1" = "ami-08dbbf1c0485a4aa8"
+    "ap-northeast-2" = "ami-0269fe7d013b8e2dd"
+    "ap-northeast-3" = "ami-0848d1e5fb6e3e3da"
+    "ap-south-1"     = "ami-020d429f17c9f1d0a"
+    "ap-southeast-1" = "ami-09625a221230d9fe6"
+    "ap-southeast-2" = "ami-03cbc6cddb06af2c2"
+    "ca-central-1"   = "ami-09125623b02302014"
+    "eu-central-1"   = "ami-00c36c60f07e21791"
+    "eu-north-1"     = "ami-052bea934e2d9dbfe"
+    "eu-south-1"     = "ami-04e2bb16d37324719"
+    "eu-west-1"      = "ami-0f87948fe2cf1b2a4"
+    "eu-west-2"      = "ami-02ed1bc837487d535"
+    "eu-west-3"      = "ami-080efd2add7e29430"
+    "me-south-1"     = "ami-0dbde382c834c4a72"
+    "sa-east-1"      = "ami-0a0792814cb068077"
+    "us-east-1"      = "ami-05dd1b6e7ef6f8378"
+    "us-east-2"      = "ami-04dd0542609808c50"
+    "us-west-1"      = "ami-07af5f877b3db9f73"
+    "us-west-2"      = "ami-0d0d8694ba492c02b"
   }
 }
 

--- a/cloud/terraform/aws_multi_region/_provider.tf
+++ b/cloud/terraform/aws_multi_region/_provider.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  alias  = "eu-west-2"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "us-west-1"
+  region = "us-west-1"
+}

--- a/cloud/terraform/aws_multi_region/main.tf
+++ b/cloud/terraform/aws_multi_region/main.tf
@@ -1,0 +1,27 @@
+module "eu-west-2" {
+  source = "./modules/multi-region"
+  ec2_vpc_id = "vpc-xxxxxxxx"
+  ec2_subnet_id = "subnet-xxxxxxxx"
+  ec2_region = "eu-west-2"
+  tpot_name = "T-Pot Honeypot"
+  
+  linux_password = var.linux_password
+  web_password = var.web_password
+  providers = {
+    aws = aws.eu-west-2
+  }
+}
+
+module "us-west-1" {
+  source = "./modules/multi-region"
+  ec2_vpc_id = "vpc-xxxxxxxx"
+  ec2_subnet_id = "subnet-xxxxxxxx"
+  ec2_region = "us-west-1"
+  tpot_name = "T-Pot Honeypot"
+
+  linux_password = var.linux_password
+  web_password = var.web_password
+  providers = {
+    aws = aws.us-west-1
+  }
+}

--- a/cloud/terraform/aws_multi_region/modules/multi-region/main.tf
+++ b/cloud/terraform/aws_multi_region/modules/multi-region/main.tf
@@ -1,0 +1,69 @@
+variable "ec2_vpc_id" {}
+variable "ec2_subnet_id" {}
+variable "ec2_region" {}
+variable "linux_password" {}
+variable "web_password" {}
+variable "tpot_name" {}
+
+resource "aws_security_group" "tpot" {
+  name        = "T-Pot"
+  description = "T-Pot Honeypot"
+  vpc_id      = var.ec2_vpc_id
+  ingress {
+    from_port   = 0
+    to_port     = 64000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 0
+    to_port     = 64000
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 64294
+    to_port     = 64294
+    protocol    = "tcp"
+    cidr_blocks = var.admin_ip
+  }
+  ingress {
+    from_port   = 64295
+    to_port     = 64295
+    protocol    = "tcp"
+    cidr_blocks = var.admin_ip
+  }
+  ingress {
+    from_port   = 64297
+    to_port     = 64297
+    protocol    = "tcp"
+    cidr_blocks = var.admin_ip
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = {
+    Name = "T-Pot"
+  }
+}
+
+resource "aws_instance" "tpot" {
+  ami           = var.ec2_ami[var.ec2_region]
+  instance_type = var.ec2_instance_type
+  key_name      = var.ec2_ssh_key_name
+  subnet_id     = var.ec2_subnet_id
+  tags = {
+    Name = var.tpot_name
+  }
+  root_block_device {
+    volume_type           = "gp2"
+    volume_size           = 128
+    delete_on_termination = true
+  }
+  user_data                   = templatefile("../cloud-init.yaml", { timezone = var.timezone, password = var.linux_password, tpot_flavor = var.tpot_flavor, web_user = var.web_user, web_password = var.web_password })
+  vpc_security_group_ids      = [aws_security_group.tpot.id]
+  associate_public_ip_address = true
+}

--- a/cloud/terraform/aws_multi_region/modules/multi-region/outputs.tf
+++ b/cloud/terraform/aws_multi_region/modules/multi-region/outputs.tf
@@ -1,0 +1,12 @@
+output "Admin_UI" {
+  value = "https://${aws_instance.tpot.public_dns}:64294/"
+}
+
+output "SSH_Access" {
+  value = "ssh -i {private_key_file} -p 64295 admin@${aws_instance.tpot.public_dns}"
+}
+
+output "Web_UI" {
+  value = "https://${aws_instance.tpot.public_dns}:64297/"
+}
+

--- a/cloud/terraform/aws_multi_region/modules/multi-region/variables.tf
+++ b/cloud/terraform/aws_multi_region/modules/multi-region/variables.tf
@@ -12,31 +12,31 @@ variable "ec2_instance_type" {
   default = "t3.xlarge"
 }
 
-# Refer to https://wiki.debian.org/Cloud/AmazonEC2Image/Buster
+# Refer to https://wiki.debian.org/Cloud/AmazonEC2Image/Bullseye
 variable "ec2_ami" {
   type = map(string)
   default = {
-    "af-south-1"     = "ami-0272d4f5fb1b98a0d"
-    "ap-east-1"      = "ami-00d242e2f23abf6d2"
-    "ap-northeast-1" = "ami-001c6b4d627e8be53"
-    "ap-northeast-2" = "ami-0d841ed4bf80e764c"
-    "ap-northeast-3" = "ami-01b0a01d770321320"
-    "ap-south-1"     = "ami-04ba7e5bd7c6f6929"
-    "ap-southeast-1" = "ami-0dca3eabb09c32ae2"
-    "ap-southeast-2" = "ami-03ff8684dc585ddae"
-    "ca-central-1"   = "ami-08af22d7c0382fd83"
-    "eu-central-1"   = "ami-0f41e297b3c53fab8"
-    "eu-north-1"     = "ami-0bbc6a00971c77d6d"
-    "eu-south-1"     = "ami-03ff8684dc585ddae"
-    "eu-west-1"      = "ami-080684ad73d431a05"
-    "eu-west-2"      = "ami-04b259723891dfc53"
-    "eu-west-3"      = "ami-00662eead74f66895"
-    "me-south-1"     = "ami-021a6c6047091ab5b"
-    "sa-east-1"      = "ami-0aac091cce68a049c"
-    "us-east-1"      = "ami-05ad4ed7f9c48178b"
-    "us-east-2"      = "ami-07640f3f27c0ad3d3"
-    "us-west-1"      = "ami-0c053f1d5f22eb09f"
-    "us-west-2"      = "ami-090cd3aed687b1ee1"
+    "af-south-1"     = "ami-0c372f041acae6d49"
+    "ap-east-1"      = "ami-079b8d011d4655385"
+    "ap-northeast-1" = "ami-08dbbf1c0485a4aa8"
+    "ap-northeast-2" = "ami-0269fe7d013b8e2dd"
+    "ap-northeast-3" = "ami-0848d1e5fb6e3e3da"
+    "ap-south-1"     = "ami-020d429f17c9f1d0a"
+    "ap-southeast-1" = "ami-09625a221230d9fe6"
+    "ap-southeast-2" = "ami-03cbc6cddb06af2c2"
+    "ca-central-1"   = "ami-09125623b02302014"
+    "eu-central-1"   = "ami-00c36c60f07e21791"
+    "eu-north-1"     = "ami-052bea934e2d9dbfe"
+    "eu-south-1"     = "ami-04e2bb16d37324719"
+    "eu-west-1"      = "ami-0f87948fe2cf1b2a4"
+    "eu-west-2"      = "ami-02ed1bc837487d535"
+    "eu-west-3"      = "ami-080efd2add7e29430"
+    "me-south-1"     = "ami-0dbde382c834c4a72"
+    "sa-east-1"      = "ami-0a0792814cb068077"
+    "us-east-1"      = "ami-05dd1b6e7ef6f8378"
+    "us-east-2"      = "ami-04dd0542609808c50"
+    "us-west-1"      = "ami-07af5f877b3db9f73"
+    "us-west-2"      = "ami-0d0d8694ba492c02b"
   }
 }
 

--- a/cloud/terraform/aws_multi_region/modules/multi-region/variables.tf
+++ b/cloud/terraform/aws_multi_region/modules/multi-region/variables.tf
@@ -1,0 +1,57 @@
+variable "admin_ip" {
+  default     = ["152.37.108.93/32"]
+  description = "admin IP addresses in CIDR format"
+}
+
+variable "ec2_ssh_key_name" {
+  default = "default"
+}
+
+# https://aws.amazon.com/ec2/instance-types/
+variable "ec2_instance_type" {
+  default = "t3.xlarge"
+}
+
+# Refer to https://wiki.debian.org/Cloud/AmazonEC2Image/Buster
+variable "ec2_ami" {
+  type = map(string)
+  default = {
+    "af-south-1"     = "ami-0272d4f5fb1b98a0d"
+    "ap-east-1"      = "ami-00d242e2f23abf6d2"
+    "ap-northeast-1" = "ami-001c6b4d627e8be53"
+    "ap-northeast-2" = "ami-0d841ed4bf80e764c"
+    "ap-northeast-3" = "ami-01b0a01d770321320"
+    "ap-south-1"     = "ami-04ba7e5bd7c6f6929"
+    "ap-southeast-1" = "ami-0dca3eabb09c32ae2"
+    "ap-southeast-2" = "ami-03ff8684dc585ddae"
+    "ca-central-1"   = "ami-08af22d7c0382fd83"
+    "eu-central-1"   = "ami-0f41e297b3c53fab8"
+    "eu-north-1"     = "ami-0bbc6a00971c77d6d"
+    "eu-south-1"     = "ami-03ff8684dc585ddae"
+    "eu-west-1"      = "ami-080684ad73d431a05"
+    "eu-west-2"      = "ami-04b259723891dfc53"
+    "eu-west-3"      = "ami-00662eead74f66895"
+    "me-south-1"     = "ami-021a6c6047091ab5b"
+    "sa-east-1"      = "ami-0aac091cce68a049c"
+    "us-east-1"      = "ami-05ad4ed7f9c48178b"
+    "us-east-2"      = "ami-07640f3f27c0ad3d3"
+    "us-west-1"      = "ami-0c053f1d5f22eb09f"
+    "us-west-2"      = "ami-090cd3aed687b1ee1"
+  }
+}
+
+## cloud-init configuration ##
+variable "timezone" {
+  default = "UTC"
+}
+
+## These will go in the generated tpot.conf file ##
+variable "tpot_flavor" {
+  default     = "STANDARD"
+  description = "Specify your tpot flavor [STANDARD, SENSOR, INDUSTRIAL, COLLECTOR, NEXTGEN, MEDICAL]"
+}
+
+variable "web_user" {
+  default     = "webuser"
+  description = "Set a username for the web user"
+}

--- a/cloud/terraform/aws_multi_region/modules/multi-region/variables.tf
+++ b/cloud/terraform/aws_multi_region/modules/multi-region/variables.tf
@@ -1,5 +1,5 @@
 variable "admin_ip" {
-  default     = ["152.37.108.93/32"]
+  default     = ["127.0.0.1/32"]
   description = "admin IP addresses in CIDR format"
 }
 

--- a/cloud/terraform/aws_multi_region/modules/multi-region/versions.tf
+++ b/cloud/terraform/aws_multi_region/modules/multi-region/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.72.0"
+    }
+  }
+}

--- a/cloud/terraform/aws_multi_region/outputs.tf
+++ b/cloud/terraform/aws_multi_region/outputs.tf
@@ -1,0 +1,7 @@
+output "eu-west-2_Web_UI" {
+  value = module.eu-west-2.Web_UI
+}
+
+output "us-west-1_Web_UI" {
+  value = module.us-west-1.Web_UI
+}

--- a/cloud/terraform/aws_multi_region/variables.tf
+++ b/cloud/terraform/aws_multi_region/variables.tf
@@ -1,0 +1,19 @@
+variable "linux_password" {
+  #default = "LiNuXuSeRP4Ss!"
+  description = "Set a password for the default user"
+
+  validation {
+    condition     = length(var.linux_password) > 0
+    error_message = "Please specify a password for the default user."
+  }
+}
+
+variable "web_password" {
+  #default = "w3b$ecret20"
+  description = "Set a password for the web user"
+
+  validation {
+    condition     = length(var.web_password) > 0
+    error_message = "Please specify a password for the web user."
+  }
+}

--- a/cloud/terraform/cloud-init.yaml
+++ b/cloud/terraform/cloud-init.yaml
@@ -6,7 +6,7 @@ packages:
 
 runcmd:
   - curl -sS --retry 5 https://github.com
-  - git clone https://github.com/telekom-security/tpotce /root/tpot
+  - git clone -b 22.x https://github.com/telekom-security/tpotce /root/tpot
   - /root/tpot/iso/installer/install.sh --type=auto --conf=/root/tpot.conf
   - rm /root/tpot.conf
   - /sbin/shutdown -r now


### PR DESCRIPTION
Creating a template for deploying T-Pot in multiple AWS regions by terraform in one go. 

This is useful when having to deploy multiple honeypots across different regions and we want to deploy, update or stop all deployments at once.