### PR TITLE
Update deploy.sh

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -170,8 +170,8 @@ while [ 1 != 2 ]
       case "$mySELECT" in
         [c,C])
           fuGET_DEPLOY_DATA
-          fuCHECK_HIVE
 	  fuDEPLOY_SENSOR
+	  fuCHECK_HIVE
           break
           ;;
         [q,Q])


### PR DESCRIPTION
SSHPASS is only used in the Deploy Sensor function, where it deploys the SSH Key. Without a deployed SSH Key it will fail, as in the check Hive function it expects a cert based authentication, as no Password is being provided

https://github.com/telekom-security/tpotce/discussions/1153