### PR TITLE
Update updateip.sh

### DIFF
--- a/bin/updateip.sh
+++ b/bin/updateip.sh
@@ -3,7 +3,7 @@
 # If the external IP cannot be detected, the internal IP will be inherited.
 source /etc/environment
 myCHECKIFSENSOR=$(head -n 1 /opt/tpot/etc/tpot.yml | grep "Sensor" | wc -l)
-myUUID=$(lsblk -o MOUNTPOINT,UUID | grep "/" | awk '{ print $2 }')
+myUUID=$(lsblk -o MOUNTPOINT,UUID | grep -e "^/ " | awk '{ print $2 }')
 myLOCALIP=$(hostname -I | awk '{ print $1 }')
 myEXTIP=$(/opt/tpot/bin/myip.sh)
 if [ "$myEXTIP" = "" ];


### PR DESCRIPTION
**updateip.sh breaking on Debian OS installs where multiple partitions are present**

Make sure to target root partition, Debian will often come with /boot/efi or similar. This little hack will utilize regular expression to match line starting with / but having a blank after. So only root partition should match.

**Example:**
```
# lsblk -o MOUNTPOINT,UUID
MOUNTPOINT UUID

/          xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

/boot/efi  7034-6125


# echo "TEST_BEFORE=$(lsblk -o MOUNTPOINT,UUID | grep -e "/" | awk '{ print $2 }')"
TEST=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
7034-6125

# echo "TEST_FIXED=$(lsblk -o MOUNTPOINT,UUID | grep -e "^/ " | awk '{ print $2 }')"
TEST=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
```

Where i'm guessing the last outcome is the desired outcome. I think this change will help you in the long run to be more compatible with systems that have multiple partitions.