### PR TITLE
Adjust T-Pot for Docker Desktop for Windows with WSL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,10 +327,10 @@ Choose a supported distro of your choice. It is recommended to use the minimum /
 Sometimes it is just nice if you can spin up a T-Pot instance on macOS or Windows, i.e. for development, testing or just the fun of it. As Docker Desktop is rather limited not all honeypot types or T-Pot features are supported. Also remember, by default the macOS and Windows firewall are blocking access from remote, so testing is limited to the host. For production it is recommended to run T-Pot on [Linux](#choose-your-distro).<br>
 To get things up and running just follow these steps:
 1. Install Docker Desktop for [macOS](https://docs.docker.com/desktop/install/mac-install/) or [Windows](https://docs.docker.com/desktop/install/windows-install/).
-2. Clone the GitHub repository: `git clone https://github.com/telekom-security/tpotce`
+2. Clone the GitHub repository: `git clone https://github.com/telekom-security/tpotce` (in Windows make sure the code is checked out with `LF` instead of `CRLF`!)
 3. Go to: `cd ~/tpotce`
 4. Copy `cp compose/mac_win.yml ./docker-compose.yml`
-5. Create a `WEB_USER` by running `~/tpotce/genuser.sh`
+5. Create a `WEB_USER` by running `~/tpotce/genuser.sh` (macOS) or `~/tpotce/genuserwin.ps1` (Windows)
 6. Adjust the `.env` file by changing `TPOT_OSTYPE=linux` to either `mac` or `win`:
    ```
    # OSType (linux, mac, win)

--- a/compose/mac_win.yml
+++ b/compose/mac_win.yml
@@ -53,6 +53,7 @@ services:
      - ${TPOT_DOCKER_COMPOSE}:/tmp/tpot/docker-compose.yml:ro
      - ${TPOT_DATA_PATH}/blackhole:/etc/blackhole
      - ${TPOT_DATA_PATH}:/data
+     - /var/run/docker.sock:/var/run/docker.sock:ro
 
 
 ##################
@@ -190,32 +191,6 @@ services:
     volumes:
      - ${TPOT_DATA_PATH}/conpot/log:/var/log/conpot
 
-# Conpot kamstrup_382
-  conpot_kamstrup_382:
-    container_name: conpot_kamstrup_382
-    restart: always
-    depends_on:
-      tpotinit:
-        condition: service_healthy
-    environment:
-     - CONPOT_CONFIG=/etc/conpot/conpot.cfg
-     - CONPOT_JSON_LOG=/var/log/conpot/conpot_kamstrup_382.json
-     - CONPOT_LOG=/var/log/conpot/conpot_kamstrup_382.log
-     - CONPOT_TEMPLATE=kamstrup_382
-     - CONPOT_TMP=/tmp/conpot
-    tmpfs:
-     - /tmp/conpot:uid=2000,gid=2000
-    networks:
-     - conpot_local_kamstrup_382
-    ports:
-     - "1025:1025"
-     - "50100:50100"
-    image: ${TPOT_REPO}/conpot:${TPOT_VERSION}
-    pull_policy: ${TPOT_PULL_POLICY}
-    read_only: true
-    volumes:
-     - ${TPOT_DATA_PATH}/conpot/log:/var/log/conpot
-
 # Cowrie service
   cowrie:
     container_name: cowrie
@@ -303,7 +278,7 @@ services:
      - "81:81"
      - "135:135"
      # - "443:443"
-     - "445:445"
+     # - "445:445"
      - "1433:1433"
      - "1723:1723"
      - "1883:1883"

--- a/docker/tpotinit/dist/entrypoint.sh
+++ b/docker/tpotinit/dist/entrypoint.sh
@@ -330,7 +330,7 @@ if [ "${TPOT_OSTYPE}" == "linux" ];
 fi
 
 # Display open ports
-if [ "${TPOT_OSTYPE}" = "linux" ];
+if [ "${TPOT_OSTYPE}" == "linux" ];
   then
     echo
     echo "# This is a list of open ports on the host (netstat -tulpen)."
@@ -355,7 +355,7 @@ touch /tmp/success
 
 # We want to see true source for UDP packets in container (https://github.com/moby/libnetwork/issues/1994)
 # Start autoheal if running on a supported os
-if [ "${TPOT_OSTYPE}" = "linux" ];
+if [ "${TPOT_OSTYPE}" == "linux" ];
   then
     sleep 60
     echo "# Dropping UDP connection tables to improve visibility of true source IPs."

--- a/docker/tpotinit/dist/entrypoint.sh
+++ b/docker/tpotinit/dist/entrypoint.sh
@@ -32,7 +32,7 @@ check_var() {
     local var_value=$(eval echo \$$var_name)
 
     # Check if variable is set and not empty
-    if [[ -z "$var_value" ]]; 
+    if [[ -z "$var_value" ]];
       then
         echo "# Error: $var_name is not set or empty. Please check T-Pot .env config."
         echo
@@ -47,7 +47,7 @@ check_safety() {
     local var_value=$(eval echo \$$var_name)
 
     # General safety check for most variables
-    if [[ $var_value =~ [^a-zA-Z0-9_/.:-] ]]; 
+    if [[ $var_value =~ [^a-zA-Z0-9_/.:-] ]];
       then
         echo "# Error: Unsafe characters detected in $var_name. Please check T-Pot .env config."
         echo
@@ -81,7 +81,7 @@ validate_format() {
 
     case "$var_name" in
         TPOT_BLACKHOLE|TPOT_PERSISTENCE|TPOT_ATTACKMAP_TEXT)
-            if ! [[ $var_value =~ ^(ENABLED|DISABLED|on|off|true|false)$ ]]; 
+            if ! [[ $var_value =~ ^(ENABLED|DISABLED|on|off|true|false)$ ]];
               then
                 echo "# Error: Invalid value for $var_name. Expected ENABLED/DISABLED, on/off, true/false. Please check T-Pot .env config."
 		        echo
@@ -97,7 +97,7 @@ validate_ip_or_domain() {
 
     # Regular expression for validating IPv4 addresses
     local ipv4Regex='^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'
-    
+
     # Regular expression for validating domain names (including subdomains)
     local domainRegex='^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$'
 
@@ -122,7 +122,7 @@ create_web_users() {
     : > /data/nginx/conf/lswebpasswd
     for i in ${WEB_USER};
       do
-	    if [[ -n $i ]]; 
+	    if [[ -n $i ]];
 	      then
 	        # Need to control newlines as they kept coming up for some reason
 	        echo -n "$i" | base64 -d -w0 | tr -d '\n' >> /data/nginx/conf/nginxpasswd
@@ -130,9 +130,9 @@ create_web_users() {
 	    fi
     done
 
-    for i in ${LS_WEB_USER}; 
+    for i in ${LS_WEB_USER};
       do
-        if [[ -n $i ]]; 
+        if [[ -n $i ]];
           then
             # Need to control newlines as they kept coming up for some reason
             echo -n "$i" | base64 -d -w0 | tr -d '\n' >> /data/nginx/conf/lswebpasswd
@@ -297,7 +297,7 @@ if [ "${TPOT_OSTYPE}" == "linux" ];
   else
     echo
     echo "# T-Pot is configured for macOS / Windows. Blackhole is not supported."
-    echo 
+    echo
 fi
 
 # Get IP
@@ -326,7 +326,7 @@ if [ "${TPOT_OSTYPE}" == "linux" ];
   else
     echo
     echo "# T-Pot is configured for macOS / Windows. Setting up firewall rules on the host is not supported."
-    echo 
+    echo
 fi
 
 # Display open ports
@@ -342,8 +342,8 @@ if [ "${TPOT_OSTYPE}" = "linux" ];
   else
     echo
     echo "# T-Pot is configured for macOS / Windows. Showing open ports from the host is not supported."
-    echo 
-fi 
+    echo
+fi
 
 
 # Done
@@ -360,15 +360,15 @@ if [ "${TPOT_OSTYPE}" = "linux" ];
     sleep 60
     echo "# Dropping UDP connection tables to improve visibility of true source IPs."
     /usr/sbin/conntrack -D -p udp
-  else
-    # Starting container health monitoring
-    echo
-    figlet "Starting ..."
-    figlet "Autoheal"
-    echo "# Now monitoring healthcheck enabled containers to automatically restart them when unhealthy."
-    echo
-    /opt/tpot/autoheal.sh autoheal &
-    PID=$!
-    wait $PID
-    echo "# T-Pot Init and Autoheal were stopped. Exiting."
 fi
+
+# Starting container health monitoring
+echo
+figlet "Starting ..."
+figlet "Autoheal"
+echo "# Now monitoring healthcheck enabled containers to automatically restart them when unhealthy."
+echo
+/opt/tpot/autoheal.sh autoheal &
+PID=$!
+wait $PID
+echo "# T-Pot Init and Autoheal were stopped. Exiting."

--- a/dps.ps1
+++ b/dps.ps1
@@ -1,0 +1,20 @@
+# Format, colorize docker ps output
+# Define a fixed width for the STATUS column
+$statusWidth = 30
+
+# Capture the Docker output into a variable
+$dockerOutput = docker ps -f status=running -f status=exited --format "{{.Names}}`t{{.Status}}`t{{.Ports}}"
+
+# Print header with colors
+Write-Host ("NAME".PadRight(20) + "STATUS".PadRight($statusWidth) + "PORTS") -ForegroundColor Cyan -NoNewline
+Write-Host ""
+
+# Split the output into lines and loop over them
+$dockerOutput -split '\r?\n' | ForEach-Object {
+    if ($_ -ne "") {
+        $fields = $_ -split "`t"
+        Write-Host ($fields[0].PadRight(20)) -NoNewline -ForegroundColor Yellow
+        Write-Host ($fields[1].PadRight($statusWidth)) -NoNewline -ForegroundColor Green
+        Write-Host ($fields[2]) -ForegroundColor Blue
+    }
+}

--- a/genuserwin.ps1
+++ b/genuserwin.ps1
@@ -1,0 +1,12 @@
+# Run genuser.sh within tpotinit, prepare path and file
+# Define the volume paths
+$homePath = $Env:USERPROFILE + "\tpotce"
+$nginxpasswdPath = $homePath + "\data\nginx\conf\nginxpasswd"
+
+# Ensure nginxpasswd file exists
+if (-Not (Test-Path $nginxpasswdPath)) {
+    New-Item -ItemType File -Force -Path $nginxpasswdPath
+}
+
+# Run the Docker container without specifying UID / GID
+docker run -v "${homePath}:/data" --entrypoint bash -it dtagdevsec/tpotinit:24.04 "/opt/tpot/bin/genuser.sh"


### PR DESCRIPTION
Docker Desktop for Windows now uses WSL2 which identifies as `linux` as well instead of `linuxkit` as it used, too.

Also `docker compose` on Windows now handles volumes different than Linux / macOS. All host volume files need to be present at project start, which results in `nginxpasswd` being created as folder and not being recognized by `tpotinit`.