### PR TITLE
Remove Podman-Docker compatibility layer when installing

### DIFF
--- a/installer/install/tpot.yml
+++ b/installer/install/tpot.yml
@@ -296,6 +296,7 @@
           - containerd
           - runc
           - podman-docker
+          - podman
         state: absent
         update_cache: yes
       when: ansible_distribution in ["AlmaLinux", "Debian", "Fedora", "Raspbian", "Rocky", "Ubuntu"]

--- a/installer/install/tpot.yml
+++ b/installer/install/tpot.yml
@@ -287,14 +287,15 @@
   become: true
 
   tasks:
-    - name: Remove distribution based Docker packages (AlmaLinux, Debian, Fedora, Raspbian, Rocky, Ubuntu)
+    - name: Remove distribution based Docker packages and podman-docker (AlmaLinux, Debian, Fedora, Raspbian, Rocky, Ubuntu)
       package:
         name:
           - docker
           - docker-engine
           - docker.io
-          - containerd 
+          - containerd
           - runc
+          - podman-docker
         state: absent
         update_cache: yes
       when: ansible_distribution in ["AlmaLinux", "Debian", "Fedora", "Raspbian", "Rocky", "Ubuntu"]


### PR DESCRIPTION
This might be problematic on RHEL-based systems due to Podman being pushed by Red Hat.
From what I know, it only affects Fedora, Alma and Rocky.

Also, a quick trailing space fix.

BTW: T-Pot does not run on this compatibility layer, at least it didn't back on 22.04.