### PR TITLE
Fix conpot docker image errors

### DIFF
--- a/docker/conpot/dist/requirements.txt
+++ b/docker/conpot/dist/requirements.txt
@@ -1,5 +1,5 @@
 pysnmp-mibs
-pysmi
+pysmi==0.3.4
 libtaxii>=1.1.0
 crc16
 scapy==2.4.3rc1


### PR DESCRIPTION
Hello,

Today I tried to create my own docker container, but the conpot containers did not work, the container kept restarting with a similar error:
```
Traceback (most recent call last):
  File "/usr/bin/conpot", line 37, in <module>
    from conpot import protocols
  File "/usr/lib/python3.11/site-packages/conpot/protocols/__init__.py", line 28, in <module>
    from .snmp.snmp_server import SNMPServer
  File "/usr/lib/python3.11/site-packages/conpot/protocols/snmp/snmp_server.py", line 25, in <module>
    from conpot.protocols.snmp.command_responder import CommandResponder
  File "/usr/lib/python3.11/site-packages/conpot/protocols/snmp/command_responder.py", 6th line, in <module>
    from pysmi.reader import FileReader, FtpReader
```

The error is caused by the new pysmi release because the FtpReader function has been removed. (https://github.com/lextudio/pysnmp/commit/7df1e462fe15cf4ad48f59ef43df3095d95a7de5)
(I also tried pysmi==1.2.1, but that didn't work either.)



I have updated the conpot/dist/requirements.txt file, so it works again.