### PR TITLE
fix: Default version of SSL/TLS

### DIFF
--- a/docker/ciscoasa/dist/asa_server.py
+++ b/docker/ciscoasa/dist/asa_server.py
@@ -290,7 +290,10 @@ if __name__ == '__main__':
             if not cert:
                 import gencert
                 cert = gencert.gencert()
-            httpd.socket = ssl.wrap_socket(httpd.socket, certfile=cert, server_side=True)
+            context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+            context.load_cert_chain(certfile=cert)
+            httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
 
         logger.info('Starting server on port {:d}/tcp, use <Ctrl-C> to stop'.format(port))
         hpfl.log('info', 'Starting server on port {:d}/tcp, use <Ctrl-C> to stop'.format(port))


### PR DESCRIPTION
To fix the problem, we should replace the deprecated ssl.wrap_socket method with a more secure and modern approach. The recommended way is to use ssl.SSLContext or ssl.create_default_context to ensure that a secure protocol like TLS 1.2 or above is used.

Create an SSLContext object and set its minimum_version to ssl.TLSVersion.TLSv1_2. Wrap the server socket using this context instead of ssl.wrap_socket.