### PR TITLE
Update tpot.yml

### DIFF
--- a/installer/install/tpot.yml
+++ b/installer/install/tpot.yml
@@ -356,7 +356,7 @@
       shell: |
         if [ "$(dnf repolist docker-ce-stable)" == "" ];
           then
-            dnf -y config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+            dnf -y config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
         fi
       when: ansible_distribution in ["Fedora"]
       tags:


### PR DESCRIPTION
the original dnf config-manager command for fedora is incorrect and results in a syntax error. updated to working syntax