### PR TITLE
fix: modify script to accomodate ip address show without brd

### DIFF
--- a/docker/_builder/builder.sh
+++ b/docker/_builder/builder.sh
@@ -18,7 +18,7 @@ PUSH_IMAGES=false
 NO_CACHE=false
 PARALLELBUILDS=2
 UPLOAD_BANDWIDTH=40mbit # Set this to max 90% of available upload bandwidth
-INTERFACE=$(/sbin/ip address show | /usr/bin/awk '/inet.*(brd|global)/{ print $NF; exit }')
+INTERFACE=$(ip route | grep "^default" | awk '{ print $5 }')
 
 # Help message
 usage() {

--- a/docker/fatt/Dockerfile
+++ b/docker/fatt/Dockerfile
@@ -42,4 +42,4 @@ STOPSIGNAL SIGINT
 ENV PYTHONPATH /opt/fatt
 WORKDIR /opt/fatt
 USER fatt:fatt
-CMD python3 fatt.py -i $(/sbin/ip address show | /usr/bin/awk '/inet.*(brd|global)/{ print $NF; exit }') --print_output --json_logging -o log/fatt.log
+CMD python3 fatt.py -i $(ip route | grep "^default" | awk '{ print $5 }') --print_output --json_logging -o log/fatt.log

--- a/docker/glutton/Dockerfile
+++ b/docker/glutton/Dockerfile
@@ -40,4 +40,4 @@ RUN apk -U --no-cache upgrade && \
 # Start glutton 
 WORKDIR /opt/glutton
 USER 2000:2000
-CMD exec bin/server -d true -i $(/sbin/ip address show | /usr/bin/awk '/inet.*(brd|global)/{ print $NF; exit }') -l /var/log/glutton/glutton.log > /dev/null 2>&1
+CMD exec bin/server -d true -i $(ip route | grep "^default" | awk '{ print $5 }') -l /var/log/glutton/glutton.log > /dev/null 2>&1

--- a/docker/p0f/Dockerfile
+++ b/docker/p0f/Dockerfile
@@ -33,4 +33,4 @@ RUN apk --no-cache -U upgrade && \
 # Start p0f
 WORKDIR /opt/p0f
 USER p0f:p0f
-CMD exec /opt/p0f/p0f -u p0f -j -o /var/log/p0f/p0f.json -i $(/sbin/ip address show | /usr/bin/awk '/inet.*(brd|global)/{ print $NF; exit }') > /dev/null
+CMD exec /opt/p0f/p0f -u p0f -j -o /var/log/p0f/p0f.json -i $(ip route | grep "^default" | awk '{ print $5 }') > /dev/null

--- a/docker/suricata/Dockerfile
+++ b/docker/suricata/Dockerfile
@@ -37,4 +37,4 @@ RUN apk --no-cache -U upgrade && \
 #
 # Start suricata
 STOPSIGNAL SIGINT
-CMD SURICATA_CAPTURE_FILTER=$(update.sh $OINKCODE) && exec suricata -v -F $SURICATA_CAPTURE_FILTER -i $(/sbin/ip address show | /usr/bin/awk '/inet.*(brd|global)/{ print $NF; exit }')
+CMD SURICATA_CAPTURE_FILTER=$(update.sh $OINKCODE) && exec suricata -v -F $SURICATA_CAPTURE_FILTER -i $(ip route | grep "^default" | awk '{ print $5 }')

--- a/docker/suricata/Dockerfile.from.source
+++ b/docker/suricata/Dockerfile.from.source
@@ -135,4 +135,4 @@ RUN    apk -U add \
 #
 # Start suricata
 STOPSIGNAL SIGINT
-CMD SURICATA_CAPTURE_FILTER=$(update.sh $OINKCODE) && exec suricata -v -F $SURICATA_CAPTURE_FILTER -i $(/sbin/ip address show | /usr/bin/awk '/inet.*(brd|global)/{ print $NF; exit }')
+CMD SURICATA_CAPTURE_FILTER=$(update.sh $OINKCODE) && exec suricata -v -F $SURICATA_CAPTURE_FILTER -i $(ip route | grep "^default" | awk '{ print $5 }')


### PR DESCRIPTION
Fixes configuration issues with Suricata, p0f, and fatt on systems (e.g., Debian 12) where network interfaces lack a "brd" field in 
"ip address show". Modifies Dockerfiles and shell scripts to handle this scenario.