### PR TITLE
Adjust restore procedure on upgrade.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -188,6 +188,10 @@ function fuRESTORE () {
 	fi
 	echo "### Restoring T-Pot config file .env"
 	tar xvf $myARCHIVE .env -C $HOME/tpotce >/dev/null 2>&1
+	# Backupped file (.env) contains a record of the TPOT_VERSION that is used in docker-compose commmands. 
+	# We should upgrade the version in this file after restoring the backup.
+	newVERSION=$(cat version)
+	sed -i 's/^TPOT_VERSION=.*/TPOT_VERSION=${newVERSION}/' $HOME/tpotce/.env
 }
 
 ################


### PR DESCRIPTION
Upgrade script contains a restore function the restores the contents of `env` file from the backup version. This file contains a configuration of `TPOT_VERSION` variable. If this variable is outdated, when we restart the server tpot will be stared with the old version.

This PR updates the value of this variable after restoring the backup
