### PR TITLE
Fix conditional check in uninstall.sh using assignment

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -68,7 +68,7 @@ if [[ "${myANSIBLE_DISTRIBUTIONS[@]}" =~ "${myCURRENT_DISTRIBUTION}" ]];
   fi
 
 # Check type of sudo access
-if myANSIBLE_TAG="Debian";
+if [ "$myANSIBLE_TAG" = "Debian" ];
   # Debian 13 - sudo seems to apply stricter settings, we now ask for the become password
   then
   	myANSIBLE_BECOME_OPTION="--become --ask-become-pass"


### PR DESCRIPTION
The sudo access check on line 71 was using `if myANSIBLE_TAG="Debian"` which assigns "Debian" to the variable instead of comparing it. This means the then branch is always taken regardless of the actual distro.

Matches the correct pattern already used in install.sh line 254.