### PR TITLE
fix: use sudo -n detection for all distros instead of hardcoding for Debian

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -251,23 +251,17 @@ if [ ! -f installer/install/tpot.yml ] && [ ! -f tpot.yml ];
 fi
 
 # Check type of sudo access
-if [ "$myANSIBLE_TAG" = "Debian" ];
-  # Debian 13 - sudo seems to apply stricter settings, we now ask for the become password
+sudo -n true > /dev/null 2>&1
+if [ $? -eq 1 ];
   then
-  	myANSIBLE_BECOME_OPTION="--become --ask-become-pass"
+    myANSIBLE_BECOME_OPTION="--ask-become-pass"
+    echo "### ‘sudo’ not acquired, setting ansible become option to ${myANSIBLE_BECOME_OPTION}."
+    echo "### Ansible will ask for the ‘BECOME password’ which is typically the password you ‘sudo’ with."
+    echo
   else
-    sudo -n true > /dev/null 2>&1
-    if [ $? -eq 1 ];
-      then
-        myANSIBLE_BECOME_OPTION="--ask-become-pass"
-        echo "### ‘sudo‘ not acquired, setting ansible become option to ${myANSIBLE_BECOME_OPTION}."
-        echo "### Ansible will ask for the ‘BECOME password‘ which is typically the password you ’sudo’ with."
-        echo
-      else
-        myANSIBLE_BECOME_OPTION="--become"
-        echo "### ‘sudo‘ acquired, setting ansible become option to ${myANSIBLE_BECOME_OPTION}."
-        echo
-    fi
+    myANSIBLE_BECOME_OPTION="--become"
+    echo "### ‘sudo’ acquired, setting ansible become option to ${myANSIBLE_BECOME_OPTION}."
+    echo
 fi
 
 # Run Ansible Playbook


### PR DESCRIPTION
Debian systems were unconditionally set to use `--ask-become-pass`, added to handle Debian 13's stricter default sudo configuration. This breaks Debian-based systems with passwordless sudo (e.g. DietPi), causing the installer to hang waiting for interactive input.

The `sudo -n true` check already used for non-Debian systems should handle both cases correctly:
- Default Debian 13 (sudo requires password): exits 1 → `--ask-become-pass`
- Passwordless `sudo` (e.g. DietPi): exits 0 → `--become`

This PR is a small change to remove the Debian special-case and apply the same detection universally.
