### PR TITLE
Improve Updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ env bash -c "$(curl -sL https://github.com/telekom-security/tpotce/raw/master/in
 - [Maintenance](#maintenance)
   - [General Updates](#general-updates)
   - [Update Script](#update-script)
+  - [Restore Script](#restore-script)
   - [Daily Reboot](#daily-reboot)
   - [Known Issues](#known-issues)
     - [Docker Images Fail to Download](#docker-images-fail-to-download)
@@ -710,13 +711,56 @@ T-Pot releases are offered through GitHub and can be pulled using `~/tpotce/upda
 
 The update script will ...
  - ***mercilessly*** overwrite local changes to be in sync with the branch the installation follows, `master` by default
- - create a full backup of the `~/tpotce` folder
+ - write a backup to `~/tpot_backups/<date>_tpot_backup.tar` before it touches anything
  - update all files in `~/tpotce` to be in sync with that branch
- - restore your custom `ews.cfg` from `~/tpotce/data/ews/conf` and the T-Pot configuration (`~/tpotce/.env`).
+ - restore the T-Pot configuration (`~/tpotce/.env`) from that backup
  - detect the installed T-Pot edition (i.e. `SENSOR`, `MINI`, `LLM`, `TARPIT`, `MOBILE`) and restore it, using this release's `~/tpotce/compose/<edition>.yml` so that new honeypots and changes of the release are included.
- - store your previous `docker-compose.yml` in `$HOME/<date>_docker-compose.yml`. If you made changes to it (i.e. removing the `ewsposter` section or a `docker-compose.yml` built with `~/tpotce/compose/customizer.py`) you need to add them again.
+ - store your previous `docker-compose.yml` in `~/tpot_backups/<date>_docker-compose.yml`. If you made changes to it (i.e. removing the `ewsposter` section or a `docker-compose.yml` built with `~/tpotce/compose/customizer.py`) you need to add them again.
+
+The backup holds what git cannot bring back: `~/tpotce/.env`, your `docker-compose.yml`, a patch of
+your changes to tracked files, your untracked files, the commit to roll back to, and the files under
+`~/tpotce/data` that exist nowhere else - the installation `uuid`, the nginx certificate your sensors
+depend on, `hive.crt`, the `ews` configuration and the honeypot host keys. Everything else in
+`~/tpotce` is tracked and comes back from git, and the honeypot data under `~/tpotce/data` is never
+touched by an update. That keeps the archive at roughly a megabyte, which is why it is not
+compressed - on a Raspberry Pi compression would cost time for nothing. Add `--full` if you want
+`~/tpotce/data` in there as well; be aware that on a busy hive this turns a megabyte into tens of
+gigabytes.
+
+Your own Kibana objects and the ILM policy live in Elasticsearch rather than in a file, so they are
+exported into the same archive **before** T-Pot is stopped. You no longer need to export them by
+hand ahead of an update.
+
+Backups rotate: the last ten regular and the last two `--full` archives are kept, counted
+separately, and the newest is never removed. Before writing, the script checks that the archive
+still leaves 10% of the partition free - `~/tpot_backups` usually sits on the same filesystem as
+your honeypot data. If that does not work out it drops the oldest archives and degrades `--full` to
+a regular backup; if even that does not fit it stops before touching anything, leaving T-Pot up and
+running rather than filling the disk.
 
 To update from a different branch or fork, i.e. to test changes before they are merged, see [Testing a Branch](#testing-a-branch).
+
+## Restore Script
+`~/tpotce/restore.sh` puts a backup back.
+
+```
+restore.sh -l                     # list the backups and what they hold
+restore.sh                        # restore from the newest one, asking per group
+restore.sh -f <archive> -y        # restore everything from this archive, no questions
+```
+
+Without `-y` every group is offered separately, so you can bring back just the configuration
+without touching anything else. The groups are the rollback of the git checkout, your changes to
+tracked files, the configuration, your untracked files, the files under `data/`, and the Kibana
+objects with the ILM policy.
+
+T-Pot is stopped for the file part and started again for the Kibana import, because that one needs
+a running instance. The files under `data/` are restored with the owner and mode from the archive
+(`tpot:tpot`, uid/gid 2000) - without those the containers will not start.
+
+If you would rather do it by hand, the archive is a plain tar: `tar tvf <archive>` lists it,
+`MANIFEST` says which edition and commit it came from, and `rollback.txt` holds the commit to go
+back to with `cd ~/tpotce && git reset --hard $(cat rollback.txt)`.
 
 ## Daily Reboot
 By default T-Pot will add a daily reboot including some cleaning up. You can adjust this line with `sudo crontab -e` 

--- a/README.md
+++ b/README.md
@@ -713,6 +713,8 @@ The update script will ...
  - create a full backup of the `~/tpotce` folder
  - update all files in `~/tpotce` to be in sync with that branch
  - restore your custom `ews.cfg` from `~/tpotce/data/ews/conf` and the T-Pot configuration (`~/tpotce/.env`).
+ - detect the installed T-Pot edition (i.e. `SENSOR`, `MINI`, `LLM`, `TARPIT`, `MOBILE`) and restore it, using this release's `~/tpotce/compose/<edition>.yml` so that new honeypots and changes of the release are included.
+ - store your previous `docker-compose.yml` in `$HOME/<date>_docker-compose.yml`. If you made changes to it (i.e. removing the `ewsposter` section or a `docker-compose.yml` built with `~/tpotce/compose/customizer.py`) you need to add them again.
 
 To update from a different branch or fork, i.e. to test changes before they are merged, see [Testing a Branch](#testing-a-branch).
 

--- a/restore.sh
+++ b/restore.sh
@@ -1,0 +1,479 @@
+#!/bin/bash
+
+# Some global vars
+myDATE=$(date +%Y%m%d%H%M%S)
+myRED=$'\e[0;31m'
+myGREEN=$'\e[0;32m'
+myWHITE=$'\e[0;0m'
+myBLUE=$'\e[0;34m'
+
+myTPOTDIR="${HOME}/tpotce"
+myBACKUPDIR="${HOME}/tpot_backups"
+myARCHIVE=""
+myCONFIRMED=""
+myKIBANA="http://127.0.0.1:64296"
+myES="http://127.0.0.1:64298"
+
+# How long to wait for Kibana before printing the commands to run by hand. Weaker
+# hardware is allowed to take longer.
+myKIBANA_TIMEOUT="${TPOT_KIBANA_TIMEOUT:-300}"
+myTMPDIR=""
+
+# What to restore. Empty means: ask.
+myDO_GIT=""
+myDO_CONFIG=""
+myDO_PATCH=""
+myDO_UNTRACKED=""
+myDO_DATA=""
+myDO_ELASTIC=""
+
+myRESTORER=$(cat << "EOF"
+ _____     ____       _     ____           _
+|_   _|   |  _ \ ___ | |_  |  _ \ ___  ___| |_ ___  _ __ ___ _ __
+  | |_____| |_) / _ \| __| | |_) / _ \/ __| __/ _ \| '__/ _ \ '__|
+  | |_____|  __/ (_) | |_  |  _ <  __/\__ \ || (_) | | |  __/ |
+  |_|     |_|   \___/ \__| |_| \_\___||___/\__\___/|_|  \___|_|
+EOF
+)
+
+function fuPRINT_HELP () {
+	cat <<EOF
+Usage: $0 [-l] [-f <archive>] [-y]
+
+Restores a backup written by update.sh.
+
+Options:
+  -l                List the available backups and what they hold
+  -f <archive>      Restore from this archive. Default: the newest one in
+                    ${myBACKUPDIR}
+  -y                Restore everything without asking, including the rollback
+                    of the git checkout
+  -h                Show this help message
+
+Without -y every group is offered separately, so you can bring back just the
+configuration without touching anything else.
+EOF
+	exit 1
+}
+
+# Check if running with root privileges
+if [ ${EUID} -eq 0 ];
+  then
+    echo "This script should not be run as root. Please run it as a regular user."
+    echo
+    exit 1
+fi
+
+# One working directory for the whole run, gone when the script ends
+function fuTMPDIR () {
+	[ -n "${myTMPDIR}" ] && return
+	myTMPDIR=$(mktemp -d)
+	if [ ! -d "${myTMPDIR}" ];
+	  then
+	    echo "###### $myBLUE""Could not create a temporary directory.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	    echo
+	    exit 1
+	fi
+	trap 'rm -rf "${myTMPDIR}"' EXIT
+}
+
+# All archives, newest first
+function fuARCHIVE_LIST () {
+	ls -1t "${myBACKUPDIR}"/*_tpot_backup*.tar 2>/dev/null
+}
+
+# What does the archive hold?
+function fuHAS () {   # $1 = Member oder Praefix
+	grep -q "$1" "${myTMPDIR}/toc" 2>/dev/null
+}
+
+function fuLIST () {
+	local myFILE=""
+	local myKIND=""
+	echo
+	echo "### Backups in ${myBACKUPDIR} ..."
+	if [ -z "$(fuARCHIVE_LIST)" ];
+	  then
+	    echo "###### $myBLUE""No backups found.""$myWHITE"
+	    echo
+	    exit 0
+	fi
+	for myFILE in $(fuARCHIVE_LIST);
+	  do
+	    case "${myFILE}" in
+	      *_full*.tar) myKIND="full" ;;
+	      *)           myKIND="regular" ;;
+	    esac
+	    echo
+	    echo "###### $myBLUE$(basename "${myFILE}")$myWHITE  $(du -h "${myFILE}" | cut -f1), ${myKIND}"
+	    tar xOf "${myFILE}" MANIFEST 2>/dev/null | sed -n '2,8p' | sed 's/^/         /'
+	    echo "         Holds: $(tar tf "${myFILE}" 2>/dev/null | sed 's|/.*||' | sort -u | tr '\n' ' ')"
+	done
+	echo
+	exit 0
+}
+
+# Pick the archive and read its table of contents
+function fuPICK_ARCHIVE () {
+	echo
+	echo "### Looking for a backup ..."
+	if [ -z "${myARCHIVE}" ];
+	  then
+	    myARCHIVE=$(fuARCHIVE_LIST | head -1)
+	fi
+	if [ -z "${myARCHIVE}" ] || [ ! -f "${myARCHIVE}" ];
+	  then
+	    echo "###### $myBLUE""No backup found in ${myBACKUPDIR}. Name one with '-f'.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	    echo
+	    exit 1
+	fi
+	fuTMPDIR
+	if ! tar tf "${myARCHIVE}" > "${myTMPDIR}/toc" 2>"${myTMPDIR}/toc.err";
+	  then
+	    echo "###### $myBLUE""Cannot read ${myARCHIVE}.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	    sed 's/^/###### /' "${myTMPDIR}/toc.err"
+	    echo
+	    exit 1
+	fi
+	echo "###### $myBLUE${myARCHIVE}$myWHITE  $(du -h "${myARCHIVE}" | cut -f1), $(grep -c . "${myTMPDIR}/toc") entries"
+	if fuHAS "^MANIFEST$";
+	  then
+	    tar xOf "${myARCHIVE}" MANIFEST | sed 's/^/###### /'
+	  else
+	    echo "###### $myBLUE""No MANIFEST - this does not look like a backup from update.sh.""$myWHITE"" [ $myRED""WARNING""$myWHITE ]"
+	fi
+	echo
+}
+
+# Ask, unless -y was given
+function fuASK () {   # $1 = Frage
+	local myANSWER=""
+	[ -n "${myCONFIRMED}" ] && return 0
+	read -rp "###### $1 (y/n) " myANSWER
+	case "${myANSWER}" in
+	  y|Y|yes|YES) return 0 ;;
+	  *)           return 1 ;;
+	esac
+}
+
+# What is in there, and which of it should come back?
+function fuCHOOSE () {
+	echo "### What should be restored?"
+	if fuHAS "^rollback.txt$"; then
+	  fuASK "Roll the checkout back to the commit before the update?" && myDO_GIT="1"
+	fi
+	if fuHAS "^tracked.patch$"; then
+	  fuASK "Re-apply all your changes to tracked files (tracked.patch)?" && myDO_PATCH="1"
+	fi
+	if fuHAS "^env$"; then
+	  fuASK "Restore the configuration (.env and docker-compose.yml)?" && myDO_CONFIG="1"
+	fi
+	if fuHAS "^untracked/"; then
+	  fuASK "Restore your untracked files?" && myDO_UNTRACKED="1"
+	fi
+	if fuHAS "^data/"; then
+	  fuASK "Restore the files from data/ (certificates, uuid, host keys)?" && myDO_DATA="1"
+	fi
+	if fuHAS "^elastic/"; then
+	  fuASK "Import the Kibana objects and the ILM policy? T-Pot has to run for that." && myDO_ELASTIC="1"
+	fi
+	echo
+	if [ -z "${myDO_GIT}${myDO_CONFIG}${myDO_PATCH}${myDO_UNTRACKED}${myDO_DATA}${myDO_ELASTIC}" ];
+	  then
+	    echo "###### $myBLUE""Nothing selected, leaving everything as it is.""$myWHITE"
+	    echo
+	    exit 0
+	fi
+}
+
+function fuSTOP_TPOT () {
+	echo
+	echo -n "### Now stopping T-Pot ... "
+	if sudo systemctl stop tpot.service 2>/dev/null;
+	  then
+	    echo "[ $myGREEN"OK"$myWHITE ]"
+	  else
+	    echo "[ $myRED""WARNING""$myWHITE ]"
+	    echo "###### $myBLUE""No tpot.service, trying docker compose.""$myWHITE"
+	    [ -f "${myTPOTDIR}/docker-compose.yml" ] && ( cd "${myTPOTDIR}" && docker compose down ) >/dev/null 2>&1
+	fi
+}
+
+function fuSTART_TPOT () {
+	echo
+	echo -n "### Now starting T-Pot ... "
+	if sudo systemctl start tpot.service 2>/dev/null;
+	  then
+	    echo "[ $myGREEN"OK"$myWHITE ]"
+	  else
+	    echo "[ $myRED""WARNING""$myWHITE ]"
+	    echo "###### $myBLUE""Could not start tpot.service, please start T-Pot yourself.""$myWHITE"
+	    return 1
+	fi
+}
+
+# The rollback comes first: a `git reset --hard` puts .env and docker-compose.yml
+# back to the state of the commit, so it would overwrite anything done after it.
+function fuDO_GIT () {
+	local myCOMMIT=""
+	[ -z "${myDO_GIT}" ] && return
+	echo
+	echo "### Rolling the checkout back ..."
+	tar xOf "${myARCHIVE}" rollback.txt > "${myTMPDIR}/rollback.txt"
+	myCOMMIT=$(tr -d "[:space:]" < "${myTMPDIR}/rollback.txt")
+	if [ -z "${myCOMMIT}" ];
+	  then
+	    echo "###### $myBLUE""rollback.txt is empty, skipping.""$myWHITE"" [ $myRED""WARNING""$myWHITE ]"
+	    return
+	fi
+	if ! git -C "${myTPOTDIR}" cat-file -e "${myCOMMIT}^{commit}" 2>/dev/null;
+	  then
+	    echo "###### $myBLUE""Commit ${myCOMMIT} is not in ${myTPOTDIR}, skipping.""$myWHITE"" [ $myRED""WARNING""$myWHITE ]"
+	    return
+	fi
+	echo -n "###### $myBLUE Resetting to ${myCOMMIT}.$myWHITE "
+	if git -C "${myTPOTDIR}" reset -q --hard "${myCOMMIT}";
+	  then
+	    echo "[ $myGREEN"OK"$myWHITE ]"
+	  else
+	    echo " [ $myRED""NOT OK""$myWHITE ]"
+	fi
+}
+
+function fuDO_CONFIG () {
+	local myFILE=""
+	[ -z "${myDO_CONFIG}" ] && return
+	echo
+	echo "### Restoring the configuration ..."
+	if tar xf "${myARCHIVE}" -C "${myTMPDIR}" env 2>/dev/null && cp "${myTMPDIR}/env" "${myTPOTDIR}/.env";
+	  then
+	    echo "###### $myBLUE""Wrote ${myTPOTDIR}/.env.""$myWHITE"" [ $myGREEN""OK""$myWHITE ]"
+	  else
+	    echo "###### $myBLUE""Could not restore .env.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	fi
+	if fuHAS "^docker-compose.yml$";
+	  then
+	    if tar xf "${myARCHIVE}" -C "${myTMPDIR}" docker-compose.yml 2>/dev/null \
+	       && cp "${myTMPDIR}/docker-compose.yml" "${myTPOTDIR}/docker-compose.yml";
+	      then
+	        echo "###### $myBLUE""Wrote ${myTPOTDIR}/docker-compose.yml ($(head -1 "${myTPOTDIR}/docker-compose.yml")).""$myWHITE"" [ $myGREEN""OK""$myWHITE ]"
+	      else
+	        echo "###### $myBLUE""Could not restore docker-compose.yml.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	    fi
+	fi
+}
+
+# tracked.patch covers every change to tracked files, so .env and
+# docker-compose.yml as well. It describes them against the commit, which is why it
+# runs right after the rollback and still before the single-file copies - on a tree
+# where .env already holds the changed content it no longer applies. The copies
+# afterwards write the same content once more, which costs nothing and covers the
+# case where only the configuration was picked.
+function fuDO_PATCH () {
+	[ -z "${myDO_PATCH}" ] && return
+	echo
+	echo "### Re-applying your changes to tracked files ..."
+	tar xf "${myARCHIVE}" -C "${myTMPDIR}" tracked.patch 2>/dev/null
+	if [ ! -s "${myTMPDIR}/tracked.patch" ];
+	  then
+	    echo "###### $myBLUE""The patch is empty, there was nothing to re-apply.""$myWHITE"" [ $myGREEN""OK""$myWHITE ]"
+	    return
+	fi
+	if git -C "${myTPOTDIR}" apply --check "${myTMPDIR}/tracked.patch" 2>/dev/null;
+	  then
+	    git -C "${myTPOTDIR}" apply "${myTMPDIR}/tracked.patch" \
+	      && echo "###### $myBLUE""Applied.""$myWHITE"" [ $myGREEN""OK""$myWHITE ]"
+	    return
+	fi
+	if git -C "${myTPOTDIR}" apply --3way "${myTMPDIR}/tracked.patch" 2>/dev/null;
+	  then
+	    echo "###### $myBLUE""Applied with a three-way merge, please review the result.""$myWHITE"" [ $myRED""WARNING""$myWHITE ]"
+	    return
+	fi
+	cp "${myTMPDIR}/tracked.patch" "${myBACKUPDIR}/${myDATE}_tracked.patch"
+	echo "###### $myBLUE""The patch does not apply to this tree, most likely because those changes are already in place.""$myWHITE"" [ $myRED""WARNING""$myWHITE ]"
+	echo "###### $myBLUE""Left it in ${myBACKUPDIR}/${myDATE}_tracked.patch for you to look at.""$myWHITE"
+}
+
+function fuDO_UNTRACKED () {
+	[ -z "${myDO_UNTRACKED}" ] && return
+	echo
+	echo "### Restoring your untracked files ..."
+	rm -rf "${myTMPDIR}/untracked"
+	if ! tar xf "${myARCHIVE}" -C "${myTMPDIR}" untracked 2>/dev/null;
+	  then
+	    echo "###### $myBLUE""Could not read them from the archive.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	    return
+	fi
+	if ( cd "${myTMPDIR}/untracked" && tar cf - . ) | ( cd "${myTPOTDIR}" && tar xf - );
+	  then
+	    echo "###### $myBLUE""Restored $(find "${myTMPDIR}/untracked" -type f | wc -l) files.""$myWHITE"" [ $myGREEN""OK""$myWHITE ]"
+	  else
+	    echo "###### $myBLUE""Could not write them.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	fi
+}
+
+# The files under data/ belong to tpot:tpot (uid/gid 2000) with 0770. Without the
+# right modes the containers will not start, so owner and mode come from the archive
+# instead of from the caller's umask.
+function fuDO_DATA () {
+	[ -z "${myDO_DATA}" ] && return
+	echo
+	echo "### Restoring the files from data/ ..."
+	echo -n "###### $myBLUE $(grep -c '^data/' "${myTMPDIR}/toc") entries.$myWHITE "
+	if sudo tar xf "${myARCHIVE}" -C "${myTPOTDIR}" -p --numeric-owner --wildcards "data/*" 2>"${myTMPDIR}/data.err";
+	  then
+	    echo "[ $myGREEN"OK"$myWHITE ]"
+	    echo "###### $myBLUE""Owner and mode came from the archive.""$myWHITE"
+	  else
+	    echo " [ $myRED""NOT OK""$myWHITE ]"
+	    sed 's/^/###### /' "${myTMPDIR}/data.err"
+	fi
+}
+
+# The Elasticsearch import needs a running instance - unlike everything else, which
+# wants T-Pot stopped. So it runs last, after the start.
+function fuDO_ELASTIC () {
+	local myWAIT=0
+	local myOBJ=0
+	local myKEEP=""
+	[ -z "${myDO_ELASTIC}" ] && return
+	echo
+	echo "### Importing the Elasticsearch state ..."
+	rm -rf "${myTMPDIR}/elastic"
+	tar xf "${myARCHIVE}" -C "${myTMPDIR}" elastic 2>/dev/null
+	echo -n "###### $myBLUE Waiting for Kibana on ${myKIBANA} $myWHITE"
+	while [ "${myWAIT}" -lt "${myKIBANA_TIMEOUT}" ];
+	  do
+	    curl -s -f -o /dev/null --connect-timeout 3 "${myKIBANA}/api/status" && break
+	    sleep 5
+	    myWAIT=$((myWAIT+5))
+	    echo -n "."
+	done
+	if ! curl -s -f -o /dev/null "${myKIBANA}/api/status";
+	  then
+	    echo " [ $myRED""NOT OK""$myWHITE ]"
+	    # The files sit in the working directory, which is about to vanish - for the
+	    # manual route they have to stay, and the commands have to name the real path.
+	    myKEEP="${myBACKUPDIR}/${myDATE}_elastic"
+	    mkdir -p "${myKEEP}" && cp -a "${myTMPDIR}/elastic/." "${myKEEP}/" 2>/dev/null
+	    echo "###### $myBLUE""Kibana did not come up in ${myWAIT}s. The files are in ${myKEEP}, run these once it does:""$myWHITE"
+	    echo "######   $myBLUE""curl -X POST '${myKIBANA}/api/saved_objects/_import?overwrite=true' -H 'kbn-xsrf: true' --form file=@${myKEEP}/kibana_export.ndjson""$myWHITE"
+	    echo "######   $myBLUE""curl -X PUT '${myES}/_ilm/policy/tpot' -H 'Content-Type: application/json' -d @${myKEEP}/ilm_policy_tpot.json""$myWHITE"
+	    return 1
+	fi
+	echo " [ $myGREEN"OK"$myWHITE ] after ${myWAIT}s"
+	if [ -s "${myTMPDIR}/elastic/kibana_export.ndjson" ];
+	  then
+	    echo -n "###### $myBLUE Importing the Kibana objects.$myWHITE "
+	    if curl -s -f -X POST "${myKIBANA}/api/saved_objects/_import?overwrite=true" \
+	         -H "kbn-xsrf: true" --form file=@"${myTMPDIR}/elastic/kibana_export.ndjson" \
+	         -o "${myTMPDIR}/import.json";
+	      then
+	        myOBJ=$(sed -n 's/.*"successCount":\([0-9]*\).*/\1/p' "${myTMPDIR}/import.json")
+	        if grep -q '"success":true' "${myTMPDIR}/import.json";
+	          then
+	            echo "[ $myGREEN"OK"$myWHITE ] ${myOBJ:-0} objects"
+	          else
+	            echo " [ $myRED""WARNING""$myWHITE ] ${myOBJ:-0} objects, errors reported"
+	            sed 's/^/###### /' "${myTMPDIR}/import.json" | head -5
+	        fi
+	      else
+	        echo " [ $myRED""NOT OK""$myWHITE ]"
+	    fi
+	fi
+	if [ -s "${myTMPDIR}/elastic/ilm_policy_tpot.json" ];
+	  then
+	    echo -n "###### $myBLUE Putting the ILM policy back.$myWHITE "
+	    # update.sh stored it ready to be put back, so this is a plain PUT against the
+	    # Elasticsearch port every edition that ships it publishes on the loopback.
+	    if curl -s -f -X PUT "${myES}/_ilm/policy/tpot" \
+	         -H "Content-Type: application/json" \
+	         -d @"${myTMPDIR}/elastic/ilm_policy_tpot.json" -o /dev/null;
+	      then
+	        echo "[ $myGREEN"OK"$myWHITE ]"
+	      else
+	        echo " [ $myRED""WARNING""$myWHITE ]"
+	        echo "###### $myBLUE""Could not put the ILM policy back, the file is in the archive under elastic/.""$myWHITE"
+	    fi
+	fi
+}
+
+################
+# Main section #
+################
+
+while getopts ":lf:yh" opt; do
+  case "$opt" in
+    l)
+      myLIST="1"
+      ;;
+    f)
+      myARCHIVE="${OPTARG}"
+      ;;
+    y)
+      myCONFIRMED="y"
+      ;;
+    h|\?)
+      fuPRINT_HELP
+      ;;
+    :)
+      echo "Option -${OPTARG} requires an argument."
+      fuPRINT_HELP
+      ;;
+  esac
+done
+
+echo "$myRESTORER"
+
+fuTMPDIR
+[ -n "${myLIST}" ] && fuLIST
+
+if [ ! -d "${myTPOTDIR}" ];
+  then
+    echo "###### $myBLUE""There is no ${myTPOTDIR}.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+    echo
+    exit 1
+fi
+
+fuPICK_ARCHIVE
+
+if [ -n "${myCONFIRMED}" ];
+  then
+    echo "### Restoring everything from this archive."
+    fuHAS "^rollback.txt$"   && myDO_GIT="1"
+    fuHAS "^env$"            && myDO_CONFIG="1"
+    fuHAS "^tracked.patch$"  && myDO_PATCH="1"
+    fuHAS "^untracked/"      && myDO_UNTRACKED="1"
+    fuHAS "^data/"           && myDO_DATA="1"
+    fuHAS "^elastic/"        && myDO_ELASTIC="1"
+  else
+    fuCHOOSE
+fi
+
+# Phase 1 - everything that needs T-Pot stopped. If only the Elasticsearch import
+# was picked there is nothing to do here and T-Pot can keep running.
+if [ -n "${myDO_GIT}${myDO_CONFIG}${myDO_PATCH}${myDO_UNTRACKED}${myDO_DATA}" ];
+  then
+    fuSTOP_TPOT
+fi
+fuDO_GIT
+fuDO_PATCH
+fuDO_CONFIG
+fuDO_UNTRACKED
+fuDO_DATA
+
+# Phase 2 - the Elasticsearch import needs a running instance
+if [ -n "${myDO_ELASTIC}" ];
+  then
+    # If T-Pot kept running there is nothing to start
+    if [ -n "${myDO_GIT}${myDO_CONFIG}${myDO_PATCH}${myDO_UNTRACKED}${myDO_DATA}" ];
+      then
+        fuSTART_TPOT
+    fi
+    fuDO_ELASTIC
+  else
+    echo
+    echo "### Done. You can now start T-Pot using 'systemctl start tpot' or 'docker compose up -d'."
+fi
+echo

--- a/update.sh
+++ b/update.sh
@@ -21,6 +21,19 @@ data/beelzebub/key
 data/galah/cert
 data/rdphoneypot/cert"
 
+# How many archives are kept. Regular and full archives rotate separately, so a
+# full backup never pushes out the small rollback points and the other way round.
+myBACKUP_RETAIN=10
+myBACKUP_RETAIN_FULL=2
+
+# Share of the partition that has to stay free after writing. The archive usually
+# sits on the same filesystem as data/, so an oversized one takes the disk away
+# from the honeypots.
+myBACKUP_RESERVE_PERCENT=10
+
+# `--full` takes all of data/ along as well
+myFULL=""
+
 # Working directory, cleaned up when the script ends
 myTMPDIR=""
 myRED="[0;31m"
@@ -55,10 +68,13 @@ EOF
 
 function fuPRINT_HELP () {
 	cat <<EOF
-Usage: $0 -y [-b <branch>] [-r <url>]
+Usage: $0 -y [-b <branch>] [-r <url>] [--full]
 
 Options:
   -y                Confirm the update, required
+  --full            Include the whole data/ folder in the backup. Off by default:
+                    the update never touches data/, and on a busy sensor it turns
+                    a 1 MB archive into tens of GB. Kept uncompressed either way.
   -b <branch>       Branch to update from, i.e. to test a branch before it is
                     merged. The branch is checked out, so every following
                     update stays on it until another branch is requested.
@@ -119,7 +135,7 @@ function fuTMPDIR () {
 # Find a free archive name. The timestamp has second resolution, and a name that
 # already exists gets a counter - two runs must not overwrite each other.
 function fuARCHIVE_NAME () {
-	local myBASE="${myBACKUPDIR}/${myDATE}_tpot_backup"
+	local myBASE="${myBACKUPDIR}/${myDATE}_tpot_backup${myFULL:+_full}"
 	local myTRY="${myBASE}.tar"
 	local myNUM=1
 	while [ -e "${myTRY}" ];
@@ -128,6 +144,116 @@ function fuARCHIVE_NAME () {
 	    myNUM=$((myNUM+1))
 	done
 	echo "${myTRY}"
+}
+
+# All archives of one kind, oldest first
+function fuARCHIVE_LIST () {   # $1 = full | small
+	local myAll=""
+	myAll=$(ls -1tr "${myBACKUPDIR}"/*_tpot_backup*.tar 2>/dev/null)
+	[ -z "${myAll}" ] && return
+	if [ "$1" == "full" ];
+	  then echo "${myAll}" | grep "_tpot_backup_full"
+	  else echo "${myAll}" | grep -v "_tpot_backup_full"
+	fi
+}
+
+# Remove the oldest archive to make room. The newest one always stays - it is the
+# most likely rollback point.
+function fuDROP_OLDEST () {
+	local myAll="" myVictim="" myCount=0
+	myAll=$(ls -1tr "${myBACKUPDIR}"/*_tpot_backup*.tar 2>/dev/null)
+	myCount=$(echo "${myAll}" | grep -c .)
+	[ "${myCount}" -lt 2 ] && return 1
+	myVictim=$(echo "${myAll}" | head -1)
+	echo "###### $myBLUE""Removing ${myVictim} ($(du -h "${myVictim}" | cut -f1)) to make room.""$myWHITE"
+	rm -f "${myVictim}"
+}
+
+# Clean up after writing, deliberately not before: an archive is never sacrificed
+# for a backup that then fails.
+function fuROTATE () {
+	local myKind="small" myKeep="${myBACKUP_RETAIN}" myList="" myCount=0 myVictim=""
+	if [ -n "${myFULL}" ];
+	  then
+	    myKind="full"
+	    myKeep="${myBACKUP_RETAIN_FULL}"
+	fi
+	while :;
+	  do
+	    myList=$(fuARCHIVE_LIST "${myKind}")
+	    myCount=$(echo "${myList}" | grep -c .)
+	    [ "${myCount}" -le "${myKeep}" ] && break
+	    myVictim=$(echo "${myList}" | head -1)
+	    echo "###### $myBLUE""Keeping the last ${myKeep} ${myKind} backups, removing ${myVictim} ($(du -h "${myVictim}" | cut -f1)).""$myWHITE"
+	    rm -f "${myVictim}" || break
+	done
+}
+
+# Roughly what the archive needs. The allowance covers MANIFEST, the patch and the
+# Elasticsearch export that is added later.
+function fuBACKUP_SIZE () {
+	local myPATHS=() myJEWEL="" mySUM=0
+	[ -f "$HOME/tpotce/.env" ] && myPATHS+=("$HOME/tpotce/.env")
+	[ -f "$HOME/tpotce/docker-compose.yml" ] && myPATHS+=("$HOME/tpotce/docker-compose.yml")
+	if [ -n "${myFULL}" ];
+	  then
+	    [ -d "$HOME/tpotce/data" ] && myPATHS+=("$HOME/tpotce/data")
+	  else
+	    for myJEWEL in ${myJEWELS};
+	      do
+	        [ -e "$HOME/tpotce/${myJEWEL}" ] && myPATHS+=("$HOME/tpotce/${myJEWEL}")
+	      done;
+	fi
+	if [ ${#myPATHS[@]} -gt 0 ];
+	  then
+	    mySUM=$(sudo du -scb "${myPATHS[@]}" 2>/dev/null | tail -1 | cut -f1)
+	fi
+	echo $((mySUM + 4194304))
+}
+
+# Does the archive still fit without closing the disk for the honeypots? Runs
+# before fuSTOP_TPOT on purpose, so that giving up leaves T-Pot running.
+function fuCHECK_BACKUP_SPACE () {
+	local myNEED=0 myFREE=0 myTOTAL=0 myRESERVE=0
+	echo
+	echo "### Checking the space for the backup ..."
+	if ! mkdir -p "${myBACKUPDIR}" || ! chmod 0700 "${myBACKUPDIR}";
+	  then
+	    echo "###### $myBLUE""Could not prepare ${myBACKUPDIR}.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	    echo "Exiting.""$myWHITE"
+	    echo
+	    exit 1
+	fi
+	myTOTAL=$(df -B1 --output=size "${myBACKUPDIR}" 2>/dev/null | tail -1 | tr -d " ")
+	myRESERVE=$(( myTOTAL / 100 * myBACKUP_RESERVE_PERCENT ))
+	while :;
+	  do
+	    myNEED=$(fuBACKUP_SIZE)
+	    myFREE=$(df -B1 --output=avail "${myBACKUPDIR}" 2>/dev/null | tail -1 | tr -d " ")
+	    echo "###### $myBLUE""Archive needs about $((myNEED / 1048576)) MB, $((myFREE / 1048576)) MB free, keeping $((myRESERVE / 1048576)) MB in reserve.""$myWHITE"
+	    if [ $((myFREE - myNEED)) -ge "${myRESERVE}" ];
+	      then
+	        echo "###### $myBLUE""Enough room.""$myWHITE"" [ $myGREEN""OK""$myWHITE ]"
+	        echo
+	        return
+	    fi
+	    if fuDROP_OLDEST;
+	      then
+	        continue
+	    fi
+	    # Nothing left to free. A full backup is dispensable, the regular one is not.
+	    if [ -n "${myFULL}" ];
+	      then
+	        echo "###### $myBLUE""Not enough room for a full backup, falling back to the regular one.""$myWHITE"" [ $myRED""WARNING""$myWHITE ]"
+	        myFULL=""
+	        continue
+	    fi
+	    echo "###### $myBLUE""Not enough room for a backup and T-Pot needs the disk.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	    echo "###### $myBLUE""Free up space in ${myBACKUPDIR} or on the filesystem, T-Pot was left running.""$myWHITE"
+	    echo "Exiting.""$myWHITE"
+	    echo
+	    exit 1
+	done
 }
 
 # Compare repository URLs without a trailing slash or `.git`
@@ -431,17 +557,23 @@ function fuBACKUP () {
 	[ -d "${myStage}/untracked" ]          && myTARGETS="${myTARGETS} untracked"
 	[ -d "${myStage}/elastic" ]            && myTARGETS="${myTARGETS} elastic"
 
-	# These belong to tpot:tpot with 0770, which the archive has to record
-	for myJEWEL in ${myJEWELS};
-	  do
-	    [ -e "$HOME/tpotce/${myJEWEL}" ] && myJEWELLIST+=("${myJEWEL}")
-	  done;
+	# With `--full` all of data/, otherwise only the irreplaceable files. Both belong
+	# to tpot:tpot with 0770, which the archive has to record.
+	if [ -n "${myFULL}" ];
+	  then
+	    [ -d "$HOME/tpotce/data" ] && myJEWELLIST+=("data")
+	  else
+	    for myJEWEL in ${myJEWELS};
+	      do
+	        [ -e "$HOME/tpotce/${myJEWEL}" ] && myJEWELLIST+=("${myJEWEL}")
+	      done;
+	fi
 	if [ ${#myJEWELLIST[@]} -gt 0 ];
 	  then
 	    myJEWELARGS=(-C "$HOME/tpotce" "${myJEWELLIST[@]}")
 	fi
 
-	echo -n "###### $myBLUE Building archive in $myARCHIVE $myWHITE"
+	echo -n "###### $myBLUE Building ${myFULL:+full }archive in $myARCHIVE $myWHITE"
 	# A single tar run: intermediate files created under sudo belong to root and
 	# could not be moved afterwards.
 	if ! sudo tar cf "${myARCHIVE}" -p --numeric-owner \
@@ -464,6 +596,7 @@ function fuBACKUP () {
 	fi
 	echo "[ $myGREEN"OK"$myWHITE ]"
 	echo "###### $myBLUE""Archive holds $(tar tf "${myARCHIVE}" | wc -l) entries, $(du -h "${myARCHIVE}" | cut -f1).""$myWHITE"
+	fuROTATE
 	# Point at the old archives from before this directory existed, once
 	if ls "$HOME"/*_tpot_backup.tgz >/dev/null 2>&1;
 	  then
@@ -602,10 +735,24 @@ function fuRESTORE_EDITION () {
 # Main section #
 ################
 
-while getopts ":yb:r:h" opt; do
+# getopts has no long options, so `--full` is translated before they are read
+myARGV=()
+for myARG in "$@";
+  do
+    case "${myARG}" in
+      --full) myARGV+=("-F") ;;
+      *)      myARGV+=("${myARG}") ;;
+    esac
+done
+set -- "${myARGV[@]}"
+
+while getopts ":yFb:r:h" opt; do
   case "$opt" in
     y)
       myCONFIRMED="y"
+      ;;
+    F)
+      myFULL="1"
       ;;
     b)
       myTPOT_BRANCH="${OPTARG}"
@@ -643,6 +790,7 @@ fuCHECK_VERSION
 fuCHECKINET "https://index.docker.io https://github.com"
 fuCHECK_SOURCE
 fuCHECK_EDITION
+fuCHECK_BACKUP_SPACE
 fuSTOP_TPOT
 fuBACKUP
 fuSELFUPDATE "$@"

--- a/update.sh
+++ b/update.sh
@@ -619,7 +619,9 @@ function fuBACKUP () {
 	# tight inside the archive already - extracting must not widen them
 	chmod -R go-rwx "${myStage}"
 
-	myTARGETS="MANIFEST rollback.txt env tracked.patch"
+	myTARGETS="MANIFEST rollback.txt tracked.patch"
+	# Only name what is actually there, or tar stops at a missing member
+	[ -f "${myStage}/env" ]                && myTARGETS="${myTARGETS} env"
 	[ -f "${myStage}/docker-compose.yml" ] && myTARGETS="${myTARGETS} docker-compose.yml"
 	[ -d "${myStage}/untracked" ]          && myTARGETS="${myTARGETS} untracked"
 	[ -d "${myStage}/elastic" ]            && myTARGETS="${myTARGETS} elastic"

--- a/update.sh
+++ b/update.sh
@@ -14,6 +14,15 @@ myTPOT_BRANCH="${TPOT_BRANCH}"
 myTPOT_REPO_URL="${TPOT_REPO_URL}"
 myTPOT_SOURCE_GIVEN=""
 
+# The installed T-Pot edition. It only exists as the marker comment in the first
+# line of docker-compose.yml, a tracked file, so the update overwrites it with the
+# STANDARD edition. Everything needed to put it back is read before the update and
+# handed over to a restarted update.sh through the environment, see fuSELFUPDATE.
+myEDITION="${TPOT_UPDATE_EDITION}"
+myCOMPOSE_BAK="${TPOT_UPDATE_COMPOSE_BAK}"
+myCOMPOSE_CUSTOMIZED="${TPOT_UPDATE_COMPOSE_CUSTOMIZED}"
+myEDITIONS="STANDARD SENSOR MINI LLM TARPIT MOBILE MAC_WIN"
+
 myUPDATER=$(cat << "EOF"
  _____     ____       _     _   _           _       _
 |_   _|   |  _ \ ___ | |_  | | | |_ __   __| | __ _| |_ ___ _ __
@@ -117,6 +126,79 @@ function fuCHECK_SOURCE () {
 	echo
 }
 
+# The template of an edition, i.e. STANDARD -> compose/standard.yml
+function fuEDITION_TEMPLATE () {
+	echo "$HOME/tpotce/compose/$(echo "${myEDITION}" | tr '[:upper:]' '[:lower:]').yml"
+}
+
+# An edition is installed by copying one of the compose/*.yml over
+# docker-compose.yml, which is tracked by git, so the `git reset --hard` in
+# fuSELFUPDATE puts the STANDARD edition back. The edition is read here, before
+# anything is stopped, backed up or overwritten.
+function fuCHECK_EDITION () {
+	local myCOMPOSE=""
+	local myKNOWN=""
+	local i=""
+	echo
+	echo "### Checking the installed T-Pot edition ..."
+	# A restarted update.sh inherits the result of the first run, the compose file
+	# has already been reset by then and cannot be read again.
+	if [ -n "${myEDITION}" ];
+	  then
+	    echo "###### $myBLUE""Edition ${myEDITION} was detected before the restart.""$myWHITE"" [ $myGREEN""OK""$myWHITE ]"
+	    echo
+	    return
+	fi
+	# Only the tracked ./docker-compose.yml is overwritten by the update, a compose
+	# file under a different name is untracked and stays as it is.
+	myCOMPOSE=$(grep -E "^TPOT_DOCKER_COMPOSE=" "$HOME/tpotce/.env" 2>/dev/null | tail -1 | cut -d "=" -f2-)
+	myCOMPOSE="${myCOMPOSE:-./docker-compose.yml}"
+	if [ "$(basename "${myCOMPOSE}")" != "docker-compose.yml" ];
+	  then
+	    echo "###### $myBLUE""TPOT_DOCKER_COMPOSE points to ${myCOMPOSE}, which the update leaves alone.""$myWHITE"" [ $myGREEN""OK""$myWHITE ]"
+	    echo
+	    return
+	fi
+	if [ ! -f "$HOME/tpotce/docker-compose.yml" ];
+	  then
+	    echo "###### $myBLUE""There is no docker-compose.yml, so there is no edition to remember.""$myWHITE"" [ $myRED""WARNING""$myWHITE ]"
+	    echo
+	    return
+	fi
+	myEDITION=$(head -1 "$HOME/tpotce/docker-compose.yml" | sed -n 's/^# T-Pot: *//p')
+	# Only an edition that ships a template in compose/ can be restored from one, a
+	# file built with compose/customizer.py has none.
+	for i in ${myEDITIONS};
+	  do
+	    [ "${myEDITION}" == "$i" ] && myKNOWN="1"
+	  done;
+	[ -n "${myKNOWN}" ] || myEDITION="UNKNOWN"
+	# The only source for the edition once the update has overwritten the file, and
+	# for the changes of a user who edited it. Kept outside of the checkout so that
+	# `git reset --hard` cannot touch it.
+	myCOMPOSE_BAK="$HOME/${myDATE}_docker-compose.yml"
+	if ! cp "$HOME/tpotce/docker-compose.yml" "${myCOMPOSE_BAK}";
+	  then
+	    echo "###### $myBLUE""Could not save docker-compose.yml to ${myCOMPOSE_BAK}.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	    echo "Exiting.""$myWHITE"
+	    echo
+	    exit 1
+	fi
+	if [ "${myEDITION}" == "UNKNOWN" ];
+	  then
+	    echo "###### $myBLUE""Unable to determine the edition, docker-compose.yml is restored as it is.""$myWHITE"" [ $myRED""WARNING""$myWHITE ]"
+	  else
+	    # A compose file that differs from its own template was edited by the user.
+	    # The update cannot merge that, so it has to be handed back manually.
+	    if ! cmp -s "$HOME/tpotce/docker-compose.yml" "$(fuEDITION_TEMPLATE)";
+	      then
+	        myCOMPOSE_CUSTOMIZED="1"
+	    fi
+	    echo "###### $myBLUE""Edition ${myEDITION}${myCOMPOSE_CUSTOMIZED:+ (customized)}.""$myWHITE"" [ $myGREEN""OK""$myWHITE ]"
+	fi
+	echo
+}
+
 # Move the checkout over to the requested repository and branch. The branch is
 # checked out for good, so a later `update.sh -y` without options keeps updating
 # from it.
@@ -164,6 +246,11 @@ function fuSELFUPDATE () {
 	if [ "${myOLDSUM}" != "$(sha256sum "$0" | awk '{ print $1 }')" ];
 	  then
 	    echo "###### $myBLUE""Found newer version of update.sh, restarting myself.""$myWHITE"
+	    # The edition was read from a file the pull above has just overwritten, so
+	    # the restarted script cannot read it again and inherits it instead.
+	    export TPOT_UPDATE_EDITION="${myEDITION}"
+	    export TPOT_UPDATE_COMPOSE_BAK="${myCOMPOSE_BAK}"
+	    export TPOT_UPDATE_COMPOSE_CUSTOMIZED="${myCOMPOSE_CUSTOMIZED}"
 	    # `-y` is repeated on purpose: after a switch to an older branch the
 	    # restarted script is that branch's update.sh, which only looks at `$1`
 	    # for the confirmation and would just print its usage otherwise
@@ -271,7 +358,11 @@ function fuUPDATER () {
 	fuREMOVEOLDIMAGES "dtagdevsec/*:24.04"
 	fuREMOVEOLDIMAGES "ghcr.io/telekom-security/*:24.04"
 	echo
-	echo "### If you made changes to docker-compose.yml please ensure to add them again."
+	if [ -n "${myCOMPOSE_CUSTOMIZED}" ];
+	  then
+	    echo "### If you made changes to docker-compose.yml please ensure to add them again."
+	    echo "### We stored your previous docker-compose.yml in $myCOMPOSE_BAK."
+	fi
 	echo "### We stored the previous version as backup in $myARCHIVE."
 	echo "### Some updates may need an import of the latest Kibana objects as well."
 	echo "### Download the latest objects here if they recently changed:"
@@ -293,6 +384,64 @@ function fuRESTORE () {
 	# We should upgrade the version in this file after restoring the backup.
 	newVERSION=$(cat version)
 	sed -i "s/^TPOT_VERSION=.*/TPOT_VERSION=${newVERSION}/" $HOME/tpotce/.env
+}
+
+# Put the edition back that fuCHECK_EDITION found, using this release's template so
+# that the update brings its new service definitions along. Has to run before the
+# images are pulled, as every edition needs a different set of them.
+function fuRESTORE_EDITION () {
+	local myTEMPLATE=""
+	echo
+	echo "### Restoring the T-Pot edition ..."
+	if [ -z "${myEDITION}" ];
+	  then
+	    echo "###### $myBLUE""No edition was detected, nothing to restore.""$myWHITE"
+	    echo
+	    return
+	fi
+	# An update.sh from before this function existed reset docker-compose.yml to
+	# the STANDARD edition without remembering anything, in which case TPOT_TYPE in
+	# the restored .env is the only hint that is left.
+	if [ "${myEDITION}" == "STANDARD" ] || [ "${myEDITION}" == "UNKNOWN" ];
+	  then
+	    if grep -qE "^TPOT_TYPE=SENSOR" "$HOME/tpotce/.env" 2>/dev/null;
+	      then
+	        echo "###### $myBLUE""TPOT_TYPE is SENSOR, restoring the SENSOR edition instead of ${myEDITION}.""$myWHITE"" [ $myRED""WARNING""$myWHITE ]"
+	        myEDITION="SENSOR"
+	    fi
+	fi
+	[ "${myEDITION}" != "UNKNOWN" ] && myTEMPLATE=$(fuEDITION_TEMPLATE)
+	if [ -n "${myTEMPLATE}" ] && [ -f "${myTEMPLATE}" ];
+	  then
+	    echo -n "###### $myBLUE Now restoring the ${myEDITION} edition.$myWHITE "
+	    if ! cp "${myTEMPLATE}" "$HOME/tpotce/docker-compose.yml";
+	      then
+	        echo " [ $myRED""NOT OK""$myWHITE ]"
+	        echo "###### $myBLUE""Please copy ${myTEMPLATE} to ~/tpotce/docker-compose.yml manually.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	        echo
+	        return
+	    fi
+	    echo "[ $myGREEN"OK"$myWHITE ]"
+	    if [ -n "${myCOMPOSE_CUSTOMIZED}" ];
+	      then
+	        echo "###### $myBLUE""Your docker-compose.yml had been modified. The ${myEDITION} edition of this release is in place now, please add your changes again.""$myWHITE"" [ $myRED""WARNING""$myWHITE ]"
+	        echo "###### $myBLUE""Compare with: diff ${myCOMPOSE_BAK} $HOME/tpotce/docker-compose.yml""$myWHITE"
+	    fi
+	  else
+	    # Without a template the file the user had is put back unchanged, which
+	    # keeps it on the service definitions of the previous release.
+	    echo -n "###### $myBLUE Now restoring your own docker-compose.yml.$myWHITE "
+	    if ! cp "${myCOMPOSE_BAK}" "$HOME/tpotce/docker-compose.yml";
+	      then
+	        echo " [ $myRED""NOT OK""$myWHITE ]"
+	        echo "###### $myBLUE""Please copy ${myCOMPOSE_BAK} to ~/tpotce/docker-compose.yml manually.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	        echo
+	        return
+	    fi
+	    echo "[ $myGREEN"OK"$myWHITE ]"
+	    echo "###### $myBLUE""Your docker-compose.yml does not match any edition in compose/, so the changes of this release were not applied to it.""$myWHITE"" [ $myRED""WARNING""$myWHITE ]"
+	fi
+	echo
 }
 
 ################
@@ -339,12 +488,20 @@ fi
 fuCHECK_VERSION
 fuCHECKINET "https://index.docker.io https://github.com"
 fuCHECK_SOURCE
+fuCHECK_EDITION
 fuSTOP_TPOT
 fuBACKUP
 fuSELFUPDATE "$@"
-fuUPDATER
+# The config and the edition have to be back in place before the images are
+# pulled, `docker compose pull` reads both.
 fuRESTORE
+fuRESTORE_EDITION
+fuUPDATER
 
 echo
+if [ -n "${myEDITION}" ] && [ "${myEDITION}" != "UNKNOWN" ];
+  then
+    echo "### The T-Pot ${myEDITION} edition was restored to ~/tpotce/docker-compose.yml."
+fi
 echo "### Done. You can now start T-Pot using 'systemctl start tpot' or 'docker compose up -d'."
 echo

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,27 @@
 
 # Some global vars
 myCOMPOSEFILE="~/tpotce/docker-compose.yml"
-myDATE=$(date +%Y%m%d%H%M)
+myDATE=$(date +%Y%m%d%H%M%S)
+
+# Where the backups live. Its own directory with 0700, because the archives carry
+# the credentials from .env.
+myBACKUPDIR="${HOME}/tpot_backups"
+
+# What of data/ belongs in the archive: everything that exists only there and
+# cannot be reproduced. Missing paths are skipped, `hive.crt` only exists on a
+# SENSOR. The password files are deliberately left out - they are generated from
+# .env on every start.
+myJEWELS="data/uuid
+data/hive.crt
+data/nginx/cert
+data/ews/conf
+data/cowrie/keys
+data/beelzebub/key
+data/galah/cert
+data/rdphoneypot/cert"
+
+# Working directory, cleaned up when the script ends
+myTMPDIR=""
 myRED="[0;31m"
 myGREEN="[0;32m"
 myWHITE="[0;0m"
@@ -80,6 +100,34 @@ function fuCHECKINET () {
 	        fi
 	  done;
 	echo
+}
+
+# One working directory for the whole run, gone when the script ends
+function fuTMPDIR () {
+	[ -n "${myTMPDIR}" ] && return
+	myTMPDIR=$(mktemp -d)
+	if [ ! -d "${myTMPDIR}" ];
+	  then
+	    echo "###### $myBLUE""Could not create a temporary directory.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	    echo "Exiting.""$myWHITE"
+	    echo
+	    exit 1
+	fi
+	trap 'rm -rf "${myTMPDIR}"' EXIT
+}
+
+# Find a free archive name. The timestamp has second resolution, and a name that
+# already exists gets a counter - two runs must not overwrite each other.
+function fuARCHIVE_NAME () {
+	local myBASE="${myBACKUPDIR}/${myDATE}_tpot_backup"
+	local myTRY="${myBASE}.tar"
+	local myNUM=1
+	while [ -e "${myTRY}" ];
+	  do
+	    myTRY="${myBASE}_${myNUM}.tar"
+	    myNUM=$((myNUM+1))
+	done
+	echo "${myTRY}"
 }
 
 # Compare repository URLs without a trailing slash or `.git`
@@ -175,8 +223,9 @@ function fuCHECK_EDITION () {
 	[ -n "${myKNOWN}" ] || myEDITION="UNKNOWN"
 	# The only source for the edition once the update has overwritten the file, and
 	# for the changes of a user who edited it. Kept outside of the checkout so that
-	# `git reset --hard` cannot touch it.
-	myCOMPOSE_BAK="$HOME/${myDATE}_docker-compose.yml"
+	# `git reset --hard` cannot touch it, next to the backup archives.
+	mkdir -p "${myBACKUPDIR}" && chmod 0700 "${myBACKUPDIR}"
+	myCOMPOSE_BAK="${myBACKUPDIR}/${myDATE}_docker-compose.yml"
 	if ! cp "$HOME/tpotce/docker-compose.yml" "${myCOMPOSE_BAK}";
 	  then
 	    echo "###### $myBLUE""Could not save docker-compose.yml to ${myCOMPOSE_BAK}.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
@@ -251,6 +300,8 @@ function fuSELFUPDATE () {
 	    export TPOT_UPDATE_EDITION="${myEDITION}"
 	    export TPOT_UPDATE_COMPOSE_BAK="${myCOMPOSE_BAK}"
 	    export TPOT_UPDATE_COMPOSE_CUSTOMIZED="${myCOMPOSE_CUSTOMIZED}"
+	    # an `exec` does not fire the EXIT trap, so clean up here
+	    [ -n "${myTMPDIR}" ] && rm -rf "${myTMPDIR}"
 	    # `-y` is repeated on purpose: after a switch to an older branch the
 	    # restarted script is that branch's update.sh, which only looks at `$1`
 	    # for the confirmation and would just print its usage otherwise
@@ -314,26 +365,109 @@ function fuSTOP_TPOT () {
 }
 
 # Backup
+#
+# Only what cannot be restored otherwise goes in. Everything tracked comes back
+# from git and an update never touches `data/`, so what is irreplaceable are the
+# user's own changes, the configuration and a handful of files under `data/`. Hence
+# a list instead of a glob, and hence no compression: the archive is small enough
+# that compressing it would only cost time.
 function fuBACKUP () {
-	myARCHIVE="$HOME/${myDATE}_tpot_backup.tgz"
-	local myPATH=$PWD
+	local myStage=""
+	local myTARGETS=""
+	local myJEWEL=""
+	local myFILE=""
+	local myJEWELLIST=()
+	local myJEWELARGS=()
 	echo
 	echo "### Create a backup, just in case ... "
-	echo -n "###### $myBLUE Building archive in $myARCHIVE $myWHITE"
-	cd $HOME/tpotce
-	sudo tar cvf $myARCHIVE * .env >/dev/null 2>&1
-	sudo chown $LOGNAME:$LOGNAME $myARCHIVE
-	if [ $? -ne 0 ];
+	fuTMPDIR
+	if ! mkdir -p "${myBACKUPDIR}" || ! chmod 0700 "${myBACKUPDIR}";
 	  then
-	    echo " [ $myRED""NOT OK""$myWHITE ]"
-	    echo "###### $myBLUE""Something went wrong.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	    echo "###### $myBLUE""Could not prepare ${myBACKUPDIR}.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
 	    echo "Exiting.""$myWHITE"
 	    echo
-	    cd $myPATH
 	    exit 1
-	  else
-	    echo "[ $myGREEN"OK"$myWHITE ]"
-	    cd $myPATH
+	fi
+	myARCHIVE=$(fuARCHIVE_NAME)
+	myStage="${myTMPDIR}/stage"
+	mkdir -p "${myStage}"
+
+	# What git cannot bring back
+	git -C "$HOME/tpotce" diff HEAD > "${myStage}/tracked.patch"
+	git -C "$HOME/tpotce" rev-parse HEAD > "${myStage}/rollback.txt"
+	cp "$HOME/tpotce/.env" "${myStage}/env" 2>/dev/null
+	[ -f "$HOME/tpotce/docker-compose.yml" ] && cp "$HOME/tpotce/docker-compose.yml" "${myStage}/"
+
+	# Untracked files that are not ignored, with their paths
+	while IFS= read -r myFILE;
+	  do
+	    [ -z "${myFILE}" ] && continue
+	    mkdir -p "${myStage}/untracked/$(dirname "${myFILE}")"
+	    cp -a "$HOME/tpotce/${myFILE}" "${myStage}/untracked/${myFILE}" 2>/dev/null
+	  done < <(git -C "$HOME/tpotce" ls-files --others --exclude-standard)
+
+	# A note saying what this is and how to get back
+	{
+	  echo "T-Pot backup"
+	  echo "Created:      $(date '+%Y-%m-%d %H:%M:%S %z')"
+	  echo "Hostname:     $(hostname)"
+	  echo "Edition:      ${myEDITION:-unknown}"
+	  echo "TPOT_TYPE:    $(grep -E '^TPOT_TYPE=' "$HOME/tpotce/.env" 2>/dev/null | tail -1 | cut -d= -f2-)"
+	  echo "TPOT_VERSION: $(grep -E '^TPOT_VERSION=' "$HOME/tpotce/.env" 2>/dev/null | tail -1 | cut -d= -f2-)"
+	  echo "Commit:       $(git -C "$HOME/tpotce" rev-parse HEAD) ($(git -C "$HOME/tpotce" rev-parse --abbrev-ref HEAD))"
+	  echo "Repository:   $(git -C "$HOME/tpotce" remote get-url origin 2>/dev/null)"
+	  echo
+	  echo "Restore with 'restore.sh -f <this archive>'."
+	  echo "To go back to the commit before the update:"
+	  echo "  cd ~/tpotce && git reset --hard \$(cat rollback.txt)"
+	} > "${myStage}/MANIFEST"
+
+	# env and tracked.patch carry the credentials from .env, so the modes have to be
+	# tight inside the archive already - extracting must not widen them
+	chmod -R go-rwx "${myStage}"
+
+	myTARGETS="MANIFEST rollback.txt env tracked.patch"
+	[ -f "${myStage}/docker-compose.yml" ] && myTARGETS="${myTARGETS} docker-compose.yml"
+	[ -d "${myStage}/untracked" ]          && myTARGETS="${myTARGETS} untracked"
+	[ -d "${myStage}/elastic" ]            && myTARGETS="${myTARGETS} elastic"
+
+	# These belong to tpot:tpot with 0770, which the archive has to record
+	for myJEWEL in ${myJEWELS};
+	  do
+	    [ -e "$HOME/tpotce/${myJEWEL}" ] && myJEWELLIST+=("${myJEWEL}")
+	  done;
+	if [ ${#myJEWELLIST[@]} -gt 0 ];
+	  then
+	    myJEWELARGS=(-C "$HOME/tpotce" "${myJEWELLIST[@]}")
+	fi
+
+	echo -n "###### $myBLUE Building archive in $myARCHIVE $myWHITE"
+	# A single tar run: intermediate files created under sudo belong to root and
+	# could not be moved afterwards.
+	if ! sudo tar cf "${myARCHIVE}" -p --numeric-owner \
+	        -C "${myStage}" ${myTARGETS} "${myJEWELARGS[@]}" 2>"${myTMPDIR}/tar.err";
+	  then
+	    echo " [ $myRED""NOT OK""$myWHITE ]"
+	    echo "###### $myBLUE""tar failed:""$myWHITE"
+	    sed 's/^/###### /' "${myTMPDIR}/tar.err"
+	    echo "Exiting.""$myWHITE"
+	    echo
+	    exit 1
+	fi
+	if ! sudo chown "$(id -u):$(id -g)" "${myARCHIVE}" || ! chmod 0600 "${myARCHIVE}";
+	  then
+	    echo " [ $myRED""NOT OK""$myWHITE ]"
+	    echo "###### $myBLUE""Could not take ownership of ${myARCHIVE}.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	    echo "Exiting.""$myWHITE"
+	    echo
+	    exit 1
+	fi
+	echo "[ $myGREEN"OK"$myWHITE ]"
+	echo "###### $myBLUE""Archive holds $(tar tf "${myARCHIVE}" | wc -l) entries, $(du -h "${myARCHIVE}" | cut -f1).""$myWHITE"
+	# Point at the old archives from before this directory existed, once
+	if ls "$HOME"/*_tpot_backup.tgz >/dev/null 2>&1;
+	  then
+	    echo "###### $myBLUE""Note: older backups are still in $HOME, new ones go to ${myBACKUPDIR}.""$myWHITE"
 	fi
 	echo
 }
@@ -379,7 +513,27 @@ function fuRESTORE () {
 	    sed -i '/- ${TPOT_DATA_PATH}:\/data/a \ \ \ \ \ - ${TPOT_DATA_PATH}/ews/conf/ews.cfg:/opt/ewsposter/ews.cfg' $myCOMPOSEFILE
 	fi
 	echo "### Restoring T-Pot config file .env"
-	tar xvf $myARCHIVE .env -C $HOME/tpotce >/dev/null 2>&1
+	fuTMPDIR
+	# `-C` only applies to the members named after it, hence it comes first. And the
+	# return value is checked: a restore that failed silently left T-Pot starting
+	# without a web login while the run still reported "Done".
+	if ! tar xf "${myARCHIVE}" -C "${myTMPDIR}" env 2>"${myTMPDIR}/untar.err";
+	  then
+	    echo "###### $myBLUE""Could not read 'env' from ${myARCHIVE}.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	    sed 's/^/###### /' "${myTMPDIR}/untar.err"
+	    echo "###### $myBLUE""Refusing to continue with a default configuration.""$myWHITE"
+	    echo "Exiting.""$myWHITE"
+	    echo
+	    exit 1
+	fi
+	if ! cp "${myTMPDIR}/env" "$HOME/tpotce/.env";
+	  then
+	    echo "###### $myBLUE""Could not write $HOME/tpotce/.env.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
+	    echo "Exiting.""$myWHITE"
+	    echo
+	    exit 1
+	fi
+	echo "###### $myBLUE""Restored from ${myARCHIVE}.""$myWHITE"" [ $myGREEN""OK""$myWHITE ]"
 	# Backup file (.env) contains a record of the TPOT_VERSION that is used in docker-compose commmands. 
 	# We should upgrade the version in this file after restoring the backup.
 	newVERSION=$(cat version)

--- a/update.sh
+++ b/update.sh
@@ -34,6 +34,11 @@ myBACKUP_RESERVE_PERCENT=10
 # `--full` takes all of data/ along as well
 myFULL=""
 
+# Both are published on the loopback interface by every edition that ships them,
+# so neither needs a detour through a container.
+myKIBANA="http://127.0.0.1:64296"
+myES="http://127.0.0.1:64298"
+
 # Working directory, cleaned up when the script ends
 myTMPDIR=""
 myRED="[0;31m"
@@ -204,6 +209,7 @@ function fuBACKUP_SIZE () {
 	        [ -e "$HOME/tpotce/${myJEWEL}" ] && myPATHS+=("$HOME/tpotce/${myJEWEL}")
 	      done;
 	fi
+	[ -d "${myTMPDIR}/stage/elastic" ] && myPATHS+=("${myTMPDIR}/stage/elastic")
 	if [ ${#myPATHS[@]} -gt 0 ];
 	  then
 	    mySUM=$(sudo du -scb "${myPATHS[@]}" 2>/dev/null | tail -1 | cut -f1)
@@ -490,6 +496,66 @@ function fuSTOP_TPOT () {
 	echo
 }
 
+# Save the state that lives in Elasticsearch rather than in a file: the user's own
+# Kibana objects and the ILM policy the retention hangs on. Runs before fuSTOP_TPOT
+# because both need a running instance. The README used to ask the user to export
+# this by hand, and update.sh gave that hint at the end of the run - too late to
+# act on.
+function fuEXPORT_ELASTIC () {
+	local myOUT=""
+	echo
+	echo "### Saving the Elasticsearch state ..."
+	fuTMPDIR
+	myOUT="${myTMPDIR}/stage/elastic"
+	mkdir -p "${myOUT}"
+	# Two independent probes rather than one: a SENSOR runs neither service, MOBILE
+	# runs Elasticsearch without Kibana.
+	if curl -s -f -o /dev/null --connect-timeout 5 "${myKIBANA}/api/status";
+	  then
+	    echo -n "###### $myBLUE Exporting Kibana objects.$myWHITE "
+	    if curl -s -f -X POST "${myKIBANA}/api/saved_objects/_export" \
+	         -H "kbn-xsrf: true" -H "Content-Type: application/json" \
+	         -d '{"type":"*","excludeExportDetails":true}' \
+	         -o "${myOUT}/kibana_export.ndjson";
+	      then
+	        echo "[ $myGREEN"OK"$myWHITE ] $(grep -c . "${myOUT}/kibana_export.ndjson") objects"
+	      else
+	        echo " [ $myRED""WARNING""$myWHITE ]"
+	        rm -f "${myOUT}/kibana_export.ndjson"
+	    fi
+	  else
+	    echo "###### $myBLUE""Kibana is not available on ${myKIBANA}, skipping its objects.""$myWHITE"
+	fi
+	# The ILM policy is not a saved object, it comes from Elasticsearch itself. What
+	# GET returns is wrapped in the policy name, which PUT rejects, so it is stored
+	# ready to be put back - restoring it is then a single curl.
+	if curl -s -f -o /dev/null --connect-timeout 5 "${myES}";
+	  then
+	    echo -n "###### $myBLUE Exporting the ILM policy.$myWHITE "
+	    if curl -s -f "${myES}/_ilm/policy/tpot" -o "${myTMPDIR}/ilm_raw.json" \
+	       && python3 -c "
+import json
+myRAW = json.load(open('${myTMPDIR}/ilm_raw.json'))
+json.dump({'policy': myRAW['tpot']['policy']}, open('${myOUT}/ilm_policy_tpot.json', 'w'), indent=2)
+" 2>/dev/null;
+	      then
+	        echo "[ $myGREEN"OK"$myWHITE ]"
+	      else
+	        echo " [ $myRED""WARNING""$myWHITE ]"
+	        rm -f "${myOUT}/ilm_policy_tpot.json"
+	    fi
+	  else
+	    echo "###### $myBLUE""Elasticsearch is not available on ${myES}, skipping the ILM policy.""$myWHITE"
+	fi
+	if [ -z "$(ls -A "${myOUT}" 2>/dev/null)" ];
+	  then
+	    rmdir "${myOUT}" 2>/dev/null
+	  else
+	    echo "###### $myBLUE""Saved to the archive under 'elastic/'.""$myWHITE"
+	fi
+	echo
+}
+
 # Backup
 #
 # Only what cannot be restored otherwise goes in. Everything tracked comes back
@@ -515,6 +581,7 @@ function fuBACKUP () {
 	    exit 1
 	fi
 	myARCHIVE=$(fuARCHIVE_NAME)
+	# fuEXPORT_ELASTIC may already have put elastic/ in here
 	myStage="${myTMPDIR}/stage"
 	mkdir -p "${myStage}"
 
@@ -631,11 +698,11 @@ function fuUPDATER () {
 	    echo "### We stored your previous docker-compose.yml in $myCOMPOSE_BAK."
 	fi
 	echo "### We stored the previous version as backup in $myARCHIVE."
-	echo "### Some updates may need an import of the latest Kibana objects as well."
-	echo "### Download the latest objects here if they recently changed:"
+	echo "### Your own Kibana objects and the ILM policy were saved to the archive before"
+	echo "### T-Pot was stopped, 'restore.sh' can put them back."
+	echo "### Some updates ship newer Kibana objects. Download them here if they changed:"
 	echo "### https://raw.githubusercontent.com/telekom-security/tpotce/refs/heads/master/docker/tpotinit/dist/etc/objects/kibana_export.ndjson.zip"
-	echo "### Export and import the objects easily through the Kibana WebUI:"
-	echo "### Go to Kibana > Management > Saved Objects > Export / Import"
+	echo "### Import through the Kibana WebUI: Management > Saved Objects > Import"
 	echo
 }
 
@@ -791,6 +858,8 @@ fuCHECKINET "https://index.docker.io https://github.com"
 fuCHECK_SOURCE
 fuCHECK_EDITION
 fuCHECK_BACKUP_SPACE
+# The Elasticsearch export needs a running instance, so it goes before the stop
+fuEXPORT_ELASTIC
 fuSTOP_TPOT
 fuBACKUP
 fuSELFUPDATE "$@"


### PR DESCRIPTION
Improve the updater for a solution / fixes for #1813 and #1815:
- Restore the installed edition properly
- Save Kibana objects and ILM policy to backup
- Efficiently use available space for backups (without `--full` only backup things that cannot be restored via git)
- Rotate backups and check free space