### PR TITLE
fix: stop instead of restarting into an older update.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ env bash -c "$(curl -sL https://github.com/telekom-security/tpotce/raw/master/in
   - [Known Issues](#known-issues)
     - [Docker Images Fail to Download](#docker-images-fail-to-download)
     - [T-Pot Networking Fails](#t-pot-networking-fails)
-    - [Update Script Loops on a Detached HEAD](#update-script-loops-on-a-detached-head)
+    - [Update Script Loops](#update-script-loops)
   - [Start T-Pot](#start-t-pot)
   - [Stop T-Pot](#stop-t-pot)
   - [T-Pot Data Folder](#t-pot-data-folder)
@@ -754,14 +754,24 @@ When `update.sh` finds a newer version of itself it pulls, restarts, and the new
 job. Scripts older than this release do not hand anything over when they restart, so the new script
 starts from a checkout that has already been reset - your `.env` and your edition are gone by then,
 and it will happily restore the upstream defaults instead. Fetch the current `update.sh` first and
-run that, then the backup is taken before anything is reset and everything survives.
+run it with `-b master`, then the backup is taken before anything is reset and everything survives.
 ```
 cd ~/tpotce
-git switch master
 curl -fsSL -o update.sh https://raw.githubusercontent.com/telekom-security/tpotce/master/update.sh
 chmod +x update.sh
-./update.sh -y
+./update.sh -y -b master
 ```
+`-b master` is what makes this work, and switching the branch by hand beforehand is not an
+alternative: `.env` is tracked, so git refuses to leave a branch while your configuration differs
+from it. The script does the switch itself, after the backup has been written, and puts your
+configuration back afterwards. It is also what keeps the `update.sh` you just fetched in place -
+that file is tracked as well, so resetting the checkout discards it, and only a switch to `master`
+brings the very same file back.
+
+Without `-b master` the run stops after restoring your configuration and says so. It has to: your
+checkout would still be on the older release, and finishing there would pull that release's images
+and remove the ones your installation is running on.
+
 This is only needed once, coming from a release that predates this behaviour. Afterwards a plain
 `./update.sh -y` carries everything across on its own.
 
@@ -810,20 +820,31 @@ docker login
 ### T-Pot Networking Fails
 T-Pot is designed to only run on machines with a single NIC. T-Pot will try to grab the interface with the default route, however it is not guaranteed that this will always succeed. At best use T-Pot on machines with only a single NIC.
 
-### Update Script Loops on a Detached HEAD
-If `~/tpotce` is not on a branch - after `git checkout <tag>`, for example - there is no upstream to
-pull into and `git pull` refuses. Current versions of `update.sh` detect this and stop before
-anything is touched. The script shipped with 24.04.0 does not: it restarts itself whenever it finds
-a newer `update.sh` upstream, and because the pull can never succeed that condition never clears,
-so it loops and writes a backup on every pass. Interrupt it with `CTRL-C` and put the checkout back
-on a branch, then update again.
+### Update Script Loops
+The `update.sh` shipped with 24.04.0 decides whether to restart itself by comparing its own file
+against `origin/master`. That comparison only ever clears on `master`: on any other branch, and on a
+detached HEAD after a `git checkout <tag>`, its `update.sh` differs from the one on `master` no
+matter how often it pulls, so it keeps restarting itself and writes a backup on every pass. Current
+versions restart on a checksum of their own file instead, stop on a detached HEAD before anything is
+touched, and never restart into an older script.
+
+Interrupt the loop with `CTRL-C`. Every pass resets the checkout before it restarts, so your `.env`
+is back at the branch default by now, and the pass that still had your configuration is the
+**first** one. Recover it before doing anything else:
 ```
-cd ~/tpotce
-git switch master
-./update.sh -y
+ls -ltr ~/*_tpot_backup.tgz
+tar xOf ~/<the oldest archive of this run>_tpot_backup.tgz .env > ~/tpotce/.env
+grep -E "^(WEB_USER|TPOT_TYPE)=" ~/tpotce/.env
 ```
-Alternatively name the branch and let the script check it out for you, which also works from a
-detached HEAD: `./update.sh -y -b master`.
+Those archive names carry the time down to the minute only, so a loop that stayed within one minute
+wrote every pass to the same file and the last one won - if `WEB_USER` comes back empty, the login
+has to be created again with `~/tpotce/genuser.sh`. Then update with the current script, which stops
+rather than loops:
+```
+curl -fsSL -o update.sh https://raw.githubusercontent.com/telekom-security/tpotce/master/update.sh
+chmod +x update.sh
+./update.sh -y -b master
+```
 
 ## Start T-Pot
 The T-Pot service automatically starts and stops on each reboot (which occurs once on a daily basis as setup in `sudo crontab -l` during installation).

--- a/update.sh
+++ b/update.sh
@@ -39,6 +39,12 @@ myFULL=""
 # from a test run included - and only takes up disk.
 myREPOS="dtagdevsec ghcr.io/telekom-security"
 
+# Set when the checkout turns out to ship an older release than the running script.
+# Nothing after the pull is an update then: the compose file, .env and the image tags
+# all belong to the older release. The run puts the configuration back and stops
+# rather than pulling that release's images and removing the ones in use.
+myOLDER_CHECKOUT=""
+
 # Whether the image pull went through. A failed pull is not fatal on its own, but
 # T-Pot cannot start without the images, so it changes what the run reports.
 myPULLOK=""
@@ -317,7 +323,7 @@ function fuCHECK_SOURCE () {
 	if [ -z "${myTPOT_BRANCH}" ] || [ "${myTPOT_BRANCH}" == "HEAD" ];
 	  then
 	    echo "###### $myBLUE""The checkout is not on a branch (detached at $(git describe --tags --always 2>/dev/null)), so there is nothing to update from.""$myWHITE"" [ $myRED""NOT OK""$myWHITE ]"
-	    echo "###### $myBLUE""Switch to a branch first, i.e. 'git -C $HOME/tpotce switch master', or name one with '-b <branch>'.""$myWHITE"
+	    echo "###### $myBLUE""Name a branch with '-b master' and it is checked out for you, or switch by hand first: 'git -C $HOME/tpotce switch master'.""$myWHITE"
 	    echo "Exiting.""$myWHITE"
 	    echo
 	    exit 1
@@ -460,6 +466,21 @@ function fuSELFUPDATE () {
 	fi
 	if [ "${myOLDSUM}" != "$(sha256sum "$0" | awk '{ print $1 }')" ];
 	  then
+	    # A changed update.sh is not necessarily a newer one. The `git reset --hard`
+	    # above throws away a hand-placed update.sh, and `-b` to an older branch
+	    # brings that branch's script - both leave an OLDER file here. Restarting
+	    # into one is never useful: it knows nothing of the handover, so it stops
+	    # T-Pot and writes a backup a second time, and the released 24.04.0 script
+	    # keeps restarting itself forever unless the checkout is on master. The
+	    # handover variable is the marker, it only exists from 24.04.1 onwards.
+	    if ! grep -q "TPOT_UPDATE_PREPARED" "$0";
+	      then
+	        echo "###### $myBLUE""The update.sh of this checkout predates the one running, so this checkout is an older release.""$myWHITE"" [ $myRED""WARNING""$myWHITE ]"
+	        echo "###### $myBLUE""Not restarting into it. Putting the configuration back, then stopping.""$myWHITE"
+	        myOLDER_CHECKOUT="1"
+	        echo
+	        return
+	    fi
 	    echo "###### $myBLUE""Found newer version of update.sh, restarting myself.""$myWHITE"
 	    # The edition was read from a file the pull above has just overwritten, so
 	    # the restarted script cannot read it again and inherits it instead.
@@ -1078,6 +1099,25 @@ fuSELFUPDATE "$@"
 # pulled, `docker compose pull` reads both.
 fuRESTORE
 fuRESTORE_EDITION
+
+# Everything below belongs to the release of the checkout - the image tag .env now
+# carries, and the cleanup that removes every other tag. On an older checkout that
+# combination pulls the previous release and deletes the images this machine runs
+# on, so the run ends here, after the configuration is safely back.
+if [ -n "${myOLDER_CHECKOUT}" ];
+  then
+    echo
+    echo "### This is a downgrade, not an update, so nothing was pulled or removed."
+    echo "###### $myBLUE""The checkout is at $(git rev-parse --abbrev-ref HEAD 2>/dev/null), whose update.sh predates the one you started. Its .env and its compose file ask for the images of that release, and the cleanup would remove the ones in use.""$myWHITE"
+    echo "###### $myBLUE""Your configuration and your edition are back in place, no image was touched, T-Pot is stopped.""$myWHITE"
+    echo "###### $myBLUE""To update to the current release instead:""$myWHITE"
+    echo "######   $myBLUE""./update.sh -y -b master""$myWHITE"
+    echo "###### $myBLUE""To leave things as they are, start T-Pot again with 'systemctl start tpot'.""$myWHITE"
+    echo "###### $myBLUE""The backup of this run is in ${myARCHIVE}.""$myWHITE"
+    echo
+    exit 1
+fi
+
 fuUPDATER
 
 echo


### PR DESCRIPTION
update.sh is tracked, so the `git reset --hard` in fuSELFUPDATE discards a hand-placed copy of the script and restores the one the checkout ships. The checksum then differs and the run used to exec into it, which is a downgrade rather than an update: that script knows nothing of the handover, stops T-Pot and writes a backup a second time, and the version released with 24.04.0 restarts itself forever unless the checkout is on master - it compares its own file against origin/master, and that only ever clears there.

Before restarting, check whether the file on disk understands the handover at all. It does not on any release before 24.04.1, which means the whole checkout is an older release: its env.example carries the previous image tag and its compose file the previous services. Finishing the run there pulls that release's images and then removes every other tag - the ones the installation is running on. So the run puts the configuration and the edition back, says what it found, and stops before pulling anything. Also covers `-b` to an older branch and an update.sh the pull has removed.

The path documented for older releases started with `git switch master`, which fails on any real installation because .env is tracked and differs between branches. Use `./update.sh -y -b master` instead: the switch happens after the backup is written, and it is what keeps the freshly fetched script in place.